### PR TITLE
implement mission event stream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,14 @@ log4rs = "1.0"
 log = "0.4"
 mlua = { version = "0.5", default-features = false, features = ["lua51", "module", "serialize"] }
 once_cell = "1.4.0"
-prost = "0.6"
+prost = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
-tokio = { version = "0.2", features = ["rt-threaded", "time", "sync", "macros"] }
-tonic = "0.3"
+tokio = { version = "1.0", features = ["rt-multi-thread", "time", "sync"] }
+tonic = "0.4"
+
+[dev-dependencies]
+serde_json = "1.0"
 
 [build-dependencies]
 tonic-build = "0.3"

--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@ Test the running server via:
 ```bash
 grpcurl -plaintext -proto ./proto/dcs.proto -d "{\"text\": \"Works!\", \"display_time\": 10, \"clear_view\": false}" [::1]:50051 dcs.Mission/OutText
 ```
+
+or watch the mission event stream via:
+
+```bash
+grpcurl -plaintext -proto ./proto/dcs.proto -d "{}" [::1]:50051 dcs.Mission/StreamEvents
+```

--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .type_attribute(".", "#[derive(::serde::Serialize, ::serde::Deserialize)]")
         .type_attribute(".", "#[serde(rename_all = \"camelCase\")]")
-        .field_attribute("dcs.Event.event", "#[serde(flatten)]")
+        .type_attribute("dcs.Event.event", "#[serde(tag = \"type\")]")
+        .field_attribute("dcs.Event.MarkAddEvent.visibility", "#[serde(flatten)]")
+        .field_attribute("dcs.Event.MarkChangeEvent.visibility", "#[serde(flatten)]")
+        .field_attribute("dcs.Event.MarkRemoveEvent.visibility", "#[serde(flatten)]")
         .build_server(true)
         .compile(&["proto/dcs.proto"], &["proto"])?;
     Ok(())

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .type_attribute(".", "#[derive(::serde::Serialize, ::serde::Deserialize)]")
         .type_attribute(".", "#[serde(rename_all = \"camelCase\")]")
+        .field_attribute("dcs.Event.event", "#[serde(flatten)]")
         .build_server(true)
         .compile(&["proto/dcs.proto"], &["proto"])?;
     Ok(())

--- a/lua/grpc.lua
+++ b/lua/grpc.lua
@@ -95,7 +95,8 @@ local function onEvent(event)
   elseif event.id == world.event.S_EVENT_SHOT then
     grpc.event({
       time = event.time,
-      shot = {
+      event = {
+        type = "shot",
         initiator = identifier(event.initiator),
         weapon = event.weapon:getName(),
       },
@@ -119,7 +120,8 @@ local function onEvent(event)
       end
       grpc.event({
         time = event.time,
-        hit = {
+        event = {
+          type = "hit",
           initiator = identifier(event.initiator),
           weapon = weapon,
           target = target,
@@ -132,7 +134,8 @@ local function onEvent(event)
   elseif event.id == world.event.S_EVENT_TAKEOFF then
     grpc.event({
       time = event.time,
-      takeoff = {
+      event = {
+        type = "takeoff",
         initiator = identifier(event.initiator),
         place = identifier(event.place),
       },
@@ -141,7 +144,8 @@ local function onEvent(event)
   elseif event.id == world.event.S_EVENT_LAND then
     grpc.event({
       time = event.time,
-      land = {
+      event = {
+        type = "land",
         initiator = identifier(event.initiator),
         place = identifier(event.place),
       },
@@ -150,7 +154,8 @@ local function onEvent(event)
   elseif event.id == world.event.S_EVENT_CRASH then
     grpc.event({
       time = event.time,
-      crash = {
+      event = {
+        type = "crash",
         initiator = identifier(event.initiator),
       },
     })
@@ -158,7 +163,8 @@ local function onEvent(event)
   elseif event.id == world.event.S_EVENT_EJECTION then
     grpc.event({
       time = event.time,
-      ejection = {
+      event = {
+        type = "ejection",
         initiator = identifier(event.initiator),
       },
     })
@@ -166,13 +172,16 @@ local function onEvent(event)
   elseif event.id == world.event.S_EVENT_REFUELING then
     grpc.event({
       time = event.time,
-      refueling = {
+      event = {
+        type = "refueling",
         initiator = identifier(event.initiator),
       },
     })
 
   elseif event.id == world.event.S_EVENT_DEAD then
-    local payload = {}
+    local payload = {
+      type = "dead",
+    }
     if event.target:getCategory() == 2 then -- weapon
       payload.id = event.target:getName()
     else
@@ -181,13 +190,14 @@ local function onEvent(event)
 
     grpc.event({
       time = event.time,
-      dead = payload,
+      event = payload,
     })
 
   elseif event.id == world.event.S_EVENT_PILOT_DEAD then
     grpc.event({
       time = event.time,
-      pilotDead = {
+      event = {
+        type = "pilotDead",
         initiator = identifier(event.initiator),
       },
     })
@@ -195,7 +205,8 @@ local function onEvent(event)
   elseif event.id == world.event.S_EVENT_BASE_CAPTURED then
     grpc.event({
       time = event.time,
-      baseCapture = {
+      event = {
+        type = "baseCapture",
         initiator = identifier(event.initiator),
         place = identifier(event.place),
       },
@@ -204,13 +215,17 @@ local function onEvent(event)
   elseif event.id == world.event.S_EVENT_MISSION_START then
     grpc.event({
       time = event.time,
-      missionStart = {},
+      event = {
+        type = "missionStart",
+      },
     })
 
   elseif event.id == world.event.S_EVENT_MISSION_END then
     grpc.event({
       time = event.time,
-      missionEnd = {},
+      event = {
+        type = "missionEnd",
+      },
     })
 
     grpc.stop()
@@ -221,7 +236,8 @@ local function onEvent(event)
   elseif event.id == world.event.S_EVENT_REFUELING_STOP then
     grpc.event({
       time = event.time,
-      refuelingStop = {
+      event = {
+        type = "refuelingStop",
         initiator = identifier(event.initiator),
       },
     })
@@ -229,7 +245,8 @@ local function onEvent(event)
   elseif event.id == world.event.S_EVENT_BIRTH then
     grpc.event({
       time = event.time,
-      birth = {
+      event = {
+        type = "birth",
         initiator = identifier(event.initiator),
       },
     })
@@ -237,7 +254,8 @@ local function onEvent(event)
   elseif event.id == world.event.S_EVENT_HUMAN_FAILURE then
     grpc.event({
       time = event.time,
-      systemFailure = {
+      event = {
+        type = "systemFailure",
         initiator = identifier(event.initiator),
       },
     })
@@ -245,7 +263,8 @@ local function onEvent(event)
   elseif event.id == world.event.S_EVENT_ENGINE_STARTUP then
     grpc.event({
       time = event.time,
-      engineStartup = {
+      event = {
+        type = "engineStartup",
         initiator = identifier(event.initiator),
       },
     })
@@ -253,7 +272,8 @@ local function onEvent(event)
   elseif event.id == world.event.S_EVENT_ENGINE_SHUTDOWN  then
     grpc.event({
       time = event.time,
-      engineShutdown = {
+      event = {
+        type = "engineShutdown",
         initiator = identifier(event.initiator),
       },
     })
@@ -261,7 +281,8 @@ local function onEvent(event)
   elseif event.id == world.event.S_EVENT_PLAYER_ENTER_UNIT then
     grpc.event({
       time = event.time,
-      playerEnterUnit = {
+      event = {
+        type = "playerEnterUnit",
         initiator = identifier(event.initiator),
       },
     })
@@ -269,7 +290,8 @@ local function onEvent(event)
   elseif event.id == world.event.S_EVENT_PLAYER_LEAVE_UNIT then
     grpc.event({
       time = event.time,
-      playerLeaveUnit = {
+      event = {
+        type = "playerLeaveUnit",
         initiator = identifier(event.initiator),
       },
     })
@@ -279,7 +301,8 @@ local function onEvent(event)
   elseif event.id == world.event.S_EVENT_SHOOTING_START then
     grpc.event({
       time = event.time,
-      shootingStart = {
+      event = {
+        type = "shootingStart",
         initiator = identifier(event.initiator),
       },
     })
@@ -287,51 +310,67 @@ local function onEvent(event)
   elseif event.id == world.event.S_EVENT_SHOOTING_END then
     grpc.event({
       time = event.time,
-      shootingEnd = {
+      event = {
+        type = "shootingEnd",
         initiator = identifier(event.initiator),
       },
     })
 
   elseif event.id == world.event.S_EVENT_MARK_ADDED then
+    local payload = {
+      type = "markAdd",
+      initiator = identifier(event.initiator),
+      id = event.idx,
+      -- x and z are rotated here compared to group/unit coords
+      pos = { x = event.pos.z, y = event.pos.y, z = event.pos.x },
+      text = event.text,
+    }
+    if event.groupID > -1 and event.groupID then
+      payload.groupId = event.groupId
+    elseif event.coalition > -1 and event.coalition then
+      payload.coalition = event.coalition
+    end
     grpc.event({
       time = event.time,
-      markAdd = {
-        initiator = identifier(event.initiator),
-        groupId = event.groupID > -1 and event.groupID or nil,
-        coalition = event.coalition > -1 and event.coalition or nil,
-        id = event.idx,
-        -- x and z are rotated here compared to group/unit coords
-        pos = { x = event.pos.z, y = event.pos.y, z = event.pos.x },
-        text = event.text,
-      },
+      event = payload,
     })
 
   elseif event.id == world.event.S_EVENT_MARK_CHANGE then
+    local payload = {
+      type = "markChange",
+      initiator = identifier(event.initiator),
+      id = event.idx,
+      -- x and z are rotated here compared to group/unit coords
+      pos = { x = event.pos.z, y = event.pos.y, z = event.pos.x },
+      text = event.text,
+    }
+    if event.groupID > -1 and event.groupID then
+      payload.groupId = event.groupId
+    elseif event.coalition > -1 and event.coalition then
+      payload.coalition = event.coalition
+    end
     grpc.event({
       time = event.time,
-      markChange = {
-        initiator = identifier(event.initiator),
-        groupId = event.groupID > -1 and event.groupID or nil,
-        coalition = event.coalition > -1 and event.coalition or nil,
-        id = event.idx,
-        -- x and z are rotated here compared to group/unit coords
-        pos = { x = event.pos.z, y = event.pos.y, z = event.pos.x },
-        text = event.text,
-      },
+      event = payload,
     })
 
   elseif event.id == world.event.S_EVENT_MARK_REMOVED then
+    local payload = {
+      type = "markRemove",
+      initiator = identifier(event.initiator),
+      id = event.idx,
+      -- x and z are rotated here compared to group/unit coords
+      pos = { x = event.pos.z, y = event.pos.y, z = event.pos.x },
+      text = event.text,
+    }
+    if event.groupID > -1 and event.groupID then
+      payload.groupId = event.groupId
+    elseif event.coalition > -1 and event.coalition then
+      payload.coalition = event.coalition
+    end
     grpc.event({
       time = event.time,
-      markRemove = {
-        initiator = identifier(event.initiator),
-        groupId = event.groupID > -1 and event.groupID or nil,
-        coalition = event.coalition > -1 and event.coalition or nil,
-        id = event.idx,
-        -- x and z are rotated here compared to group/unit coords
-        pos = { x = event.pos.z, y = event.pos.y, z = event.pos.x },
-        text = event.text,
-      },
+      event = payload,
     })
 
   else

--- a/lua/grpc.lua
+++ b/lua/grpc.lua
@@ -89,9 +89,253 @@ local function identifier(obj)
 end
 
 local function onEvent(event)
-  if event.id == world.event.S_EVENT_MISSION_END then
+  if (event.id ~= world.event.S_EVENT_MISSION_START and event.id ~= world.event.S_EVENT_MISSION_END and event.id ~= world.event.S_EVENT_TOOK_CONTROL and event.id ~= world.event.S_EVENT_MARK_ADDED and event.id ~= world.event.S_EVENT_MARK_CHANGE and event.id ~= S_EVENT_MARK_REMOVED) and event.initiator == nil then
+    env.info("[GRPC] Ignoring event (id: "..tostring(event.id)..") with missing initiator")
+
+  elseif event.id == world.event.S_EVENT_SHOT then
+    grpc.event({
+      time = event.time,
+      shot = {
+        initiator = identifier(event.initiator),
+        weapon = event.weapon:getName(),
+      },
+    })
+
+  elseif event.id == world.event.S_EVENT_HIT then
+    if event.target ~= nil then
+      local target = {
+        -- minus one, because protobuf enums must start at zero
+        category = event.target:getCategory() - 1,
+      }
+      if target.category == 1 then -- weapon
+        target.id = event.target:getName()
+      else
+        target.name = event.target:getName()
+      end
+
+      local weapon = nil
+      if event.weapon ~= nil then
+        weapon = event.weapon:getName()
+      end
+      grpc.event({
+        time = event.time,
+        hit = {
+          initiator = identifier(event.initiator),
+          weapon = weapon,
+          target = target,
+        },
+      })
+    else
+      env.error("[GRPC] Ignoring HIT event without target")
+    end
+
+  elseif event.id == world.event.S_EVENT_TAKEOFF then
+    grpc.event({
+      time = event.time,
+      takeoff = {
+        initiator = identifier(event.initiator),
+        place = identifier(event.place),
+      },
+    })
+
+  elseif event.id == world.event.S_EVENT_LAND then
+    grpc.event({
+      time = event.time,
+      land = {
+        initiator = identifier(event.initiator),
+        place = identifier(event.place),
+      },
+    })
+
+  elseif event.id == world.event.S_EVENT_CRASH then
+    grpc.event({
+      time = event.time,
+      crash = {
+        initiator = identifier(event.initiator),
+      },
+    })
+
+  elseif event.id == world.event.S_EVENT_EJECTION then
+    grpc.event({
+      time = event.time,
+      ejection = {
+        initiator = identifier(event.initiator),
+      },
+    })
+
+  elseif event.id == world.event.S_EVENT_REFUELING then
+    grpc.event({
+      time = event.time,
+      refueling = {
+        initiator = identifier(event.initiator),
+      },
+    })
+
+  elseif event.id == world.event.S_EVENT_DEAD then
+    local payload = {}
+    if event.target:getCategory() == 2 then -- weapon
+      payload.id = event.target:getName()
+    else
+      payload.name = event.target:getName()
+    end
+
+    grpc.event({
+      time = event.time,
+      dead = payload,
+    })
+
+  elseif event.id == world.event.S_EVENT_PILOT_DEAD then
+    grpc.event({
+      time = event.time,
+      pilotDead = {
+        initiator = identifier(event.initiator),
+      },
+    })
+
+  elseif event.id == world.event.S_EVENT_BASE_CAPTURED then
+    grpc.event({
+      time = event.time,
+      baseCapture = {
+        initiator = identifier(event.initiator),
+        place = identifier(event.place),
+      },
+    })
+
+  elseif event.id == world.event.S_EVENT_MISSION_START then
+    grpc.event({
+      time = event.time,
+      missionStart = {},
+    })
+
+  elseif event.id == world.event.S_EVENT_MISSION_END then
+    grpc.event({
+      time = event.time,
+      missionEnd = {},
+    })
+
     grpc.stop()
     stopped = true
+
+  -- unimplemented: S_EVENT_TOOK_CONTROL
+
+  elseif event.id == world.event.S_EVENT_REFUELING_STOP then
+    grpc.event({
+      time = event.time,
+      refuelingStop = {
+        initiator = identifier(event.initiator),
+      },
+    })
+
+  elseif event.id == world.event.S_EVENT_BIRTH then
+    grpc.event({
+      time = event.time,
+      birth = {
+        initiator = identifier(event.initiator),
+      },
+    })
+
+  elseif event.id == world.event.S_EVENT_HUMAN_FAILURE then
+    grpc.event({
+      time = event.time,
+      systemFailure = {
+        initiator = identifier(event.initiator),
+      },
+    })
+
+  elseif event.id == world.event.S_EVENT_ENGINE_STARTUP then
+    grpc.event({
+      time = event.time,
+      engineStartup = {
+        initiator = identifier(event.initiator),
+      },
+    })
+
+  elseif event.id == world.event.S_EVENT_ENGINE_SHUTDOWN  then
+    grpc.event({
+      time = event.time,
+      engineShutdown = {
+        initiator = identifier(event.initiator),
+      },
+    })
+
+  elseif event.id == world.event.S_EVENT_PLAYER_ENTER_UNIT then
+    grpc.event({
+      time = event.time,
+      playerEnterUnit = {
+        initiator = identifier(event.initiator),
+      },
+    })
+
+  elseif event.id == world.event.S_EVENT_PLAYER_LEAVE_UNIT then
+    grpc.event({
+      time = event.time,
+      playerLeaveUnit = {
+        initiator = identifier(event.initiator),
+      },
+    })
+
+    -- unimplemented: S_EVENT_PLAYER_COMMENT
+
+  elseif event.id == world.event.S_EVENT_SHOOTING_START then
+    grpc.event({
+      time = event.time,
+      shootingStart = {
+        initiator = identifier(event.initiator),
+      },
+    })
+
+  elseif event.id == world.event.S_EVENT_SHOOTING_END then
+    grpc.event({
+      time = event.time,
+      shootingEnd = {
+        initiator = identifier(event.initiator),
+      },
+    })
+
+  elseif event.id == world.event.S_EVENT_MARK_ADDED then
+    grpc.event({
+      time = event.time,
+      markAdd = {
+        initiator = identifier(event.initiator),
+        groupId = event.groupID > -1 and event.groupID or nil,
+        coalition = event.coalition > -1 and event.coalition or nil,
+        id = event.idx,
+        -- x and z are rotated here compared to group/unit coords
+        pos = { x = event.pos.z, y = event.pos.y, z = event.pos.x },
+        text = event.text,
+      },
+    })
+
+  elseif event.id == world.event.S_EVENT_MARK_CHANGE then
+    grpc.event({
+      time = event.time,
+      markChange = {
+        initiator = identifier(event.initiator),
+        groupId = event.groupID > -1 and event.groupID or nil,
+        coalition = event.coalition > -1 and event.coalition or nil,
+        id = event.idx,
+        -- x and z are rotated here compared to group/unit coords
+        pos = { x = event.pos.z, y = event.pos.y, z = event.pos.x },
+        text = event.text,
+      },
+    })
+
+  elseif event.id == world.event.S_EVENT_MARK_REMOVED then
+    grpc.event({
+      time = event.time,
+      markRemove = {
+        initiator = identifier(event.initiator),
+        groupId = event.groupID > -1 and event.groupID or nil,
+        coalition = event.coalition > -1 and event.coalition or nil,
+        id = event.idx,
+        -- x and z are rotated here compared to group/unit coords
+        pos = { x = event.pos.z, y = event.pos.y, z = event.pos.x },
+        text = event.text,
+      },
+    })
+
+  else
+    env.info("[GRPC] Skipping unimplemented event id "..tostring(event.id))
   end
 end
 

--- a/lua/grpc.lua
+++ b/lua/grpc.lua
@@ -88,6 +88,15 @@ local function identifier(obj)
   return obj:getName()
 end
 
+local function toLatLonPosition(pos)
+  local lat, lon, alt = coord.LOtoLL(pos)
+  return {
+    lat = lat,
+    lon = lon,
+    alt = alt,
+  }
+end
+
 local function onEvent(event)
   if (event.id ~= world.event.S_EVENT_MISSION_START and event.id ~= world.event.S_EVENT_MISSION_END and event.id ~= world.event.S_EVENT_TOOK_CONTROL and event.id ~= world.event.S_EVENT_MARK_ADDED and event.id ~= world.event.S_EVENT_MARK_CHANGE and event.id ~= S_EVENT_MARK_REMOVED) and event.initiator == nil then
     env.info("[GRPC] Ignoring event (id: "..tostring(event.id)..") with missing initiator")
@@ -321,8 +330,7 @@ local function onEvent(event)
       type = "markAdd",
       initiator = identifier(event.initiator),
       id = event.idx,
-      -- x and z are rotated here compared to group/unit coords
-      pos = { x = event.pos.z, y = event.pos.y, z = event.pos.x },
+      pos = toLatLonPosition(event.pos),
       text = event.text,
     }
     if event.groupID > -1 and event.groupID then
@@ -340,8 +348,7 @@ local function onEvent(event)
       type = "markChange",
       initiator = identifier(event.initiator),
       id = event.idx,
-      -- x and z are rotated here compared to group/unit coords
-      pos = { x = event.pos.z, y = event.pos.y, z = event.pos.x },
+      pos = toLatLonPosition(event.pos),
       text = event.text,
     }
     if event.groupID > -1 and event.groupID then
@@ -359,8 +366,7 @@ local function onEvent(event)
       type = "markRemove",
       initiator = identifier(event.initiator),
       id = event.idx,
-      -- x and z are rotated here compared to group/unit coords
-      pos = { x = event.pos.z, y = event.pos.y, z = event.pos.x },
+      pos = toLatLonPosition(event.pos),
       text = event.text,
     }
     if event.groupID > -1 and event.groupID then

--- a/proto/dcs.proto
+++ b/proto/dcs.proto
@@ -52,9 +52,9 @@ message Event {
   }
 
   message Position {
-    double x = 1;
-    double y = 2; // alt
-    double z = 3; // y
+    double lat = 1;
+    double lon = 2;
+    double alt = 3; // in meters
   }
 
   // Occurs when a unit fires a weapon (but no machine gun- or autocannon-based

--- a/proto/dcs.proto
+++ b/proto/dcs.proto
@@ -8,9 +8,7 @@ message OutTextRequest {
   bool clear_view = 3;
 }
 
-message OutTextResponse {
-  bool success = 1;
-}
+message OutTextResponse {}
 
 message GetUserFlagRequest {
   string flag = 1;
@@ -25,17 +23,270 @@ message SetUserFlagRequest {
   uint32 value = 2;
 }
 
-message SetUserFlagResponse {
-  bool success = 1;
+message SetUserFlagResponse {}
+
+message StreamEventsRequest {}
+
+message Event {
+  enum ObjectCategory {
+    UNIT = 0;
+    WEAPON = 1;
+    STATIC = 2;
+    SCENERY = 3;
+    BASE = 4;
+    CARGO = 5;
+  }
+
+  enum Coalition {
+    NEUTRAL = 0;
+    RED = 1;
+    BLUE = 2;
+  }
+
+  message Target {
+    ObjectCategory category = 1;
+    oneof target {
+      uint64 id = 2;
+      string name = 3;
+    }
+  }
+
+  message Position {
+    double x = 1;
+    double y = 2; // alt
+    double z = 3; // y
+  }
+
+  // Occurs when a unit fires a weapon (but no machine gun- or autocannon-based
+  // weapons - those are handled by [ShootingStartEvent]).
+  message ShotEvent {
+    // The unit that fired the weapon.
+    string initiator = 1;
+    // The weapon that has been fired.
+    uint64 weapon = 2;
+  }
+
+  // Occurs when an object is hit by a weapon.
+  message HitEvent {
+    // The unit that fired the weapon.
+    string initiator = 1;
+    // The weapon that the target has been hit with.
+    uint64 weapon = 2;
+    // The object that has been hit.
+    Target target = 3;
+  }
+
+  // Occurs when an aircraft takes off from an airbase, farp, or ship.
+  message TakeoffEvent {
+    // The unit that took off.
+    string initiator = 1;
+    // The airbase, farp or ship the unit took off from.
+    string place = 2;
+  }
+
+  // Occurs when an aircraft lands at an airbase, farp or ship.
+  message LandEvent {
+    // The unit that landed.
+    string initiator = 1;
+    // The airbase, farp or ship the unit landed at.
+    string place = 2;
+  }
+
+  // Occurs when an aircraft crashes into the ground and is completely
+  // destroyed.
+  message CrashEvent {
+    // The unit that crashed.
+    string initiator = 1;
+  }
+
+  // Occurs when a pilot ejects from its aircraft.
+  message EjectionEvent {
+    // The unit a pilot ejected from.
+    string initiator = 1;
+  }
+
+  // Occurs when an aircraft connects with a tanker and begins taking on fuel.
+  message RefuelingEvent {
+    // The unit that is receiving fuel.
+    string initiator = 1;
+  }
+
+  // Occurs when an object is completely destroyed.
+  message DeadEvent {
+    // The unit that has been destroyed.
+    oneof initiator {
+      uint64 id = 2;
+      string name = 3;
+    }
+  }
+
+  // Occurs when a pilot of an aircraft is killed. Can occur either if the
+  // player is alive and crashes (in this case both this and the [CrashEvent]
+  // event will be fired) or if a weapon kills the pilot without completely
+  // destroying the plane.
+  message PilotDeadEvent {
+    // The unit the pilot has died in.
+    string initiator = 1;
+  }
+
+  // Occurs when a ground unit captures either an airbase or a farp.
+  message BaseCaptureEvent {
+    // The unit that captured the base.
+    string initiator = 1;
+    // The airbase that was captured, can be a FARP or Airbase
+    string place = 2;
+  }
+
+  // Occurs when the mission starts.
+  message MissionStartEvent {}
+
+  // Occurs when the mission stops.
+  message MissionEndEvent {}
+
+  // Occurs when an aircraft is finished taking fuel.
+  message RefuelingStopEvent {
+    // he unit that was receiving fuel.
+    string initiator = 1;
+  }
+
+  // Occurs when any object is spawned into the mission.
+  message BirthEvent {
+    // The unit that was spawned.
+    string initiator = 1;
+  }
+
+  // Occurs when a system fails on a human controlled aircraft occurs.
+  message SystemFailureEvent {
+    // The unit the system failure occurred in.
+    string initiator = 1;
+  }
+
+  // Occurs when any aircraft starts its engines.
+  message EngineStartupEvent {
+    // The unit that starts its engines.
+    string initiator = 1;
+  }
+
+  message EngineShutdownEvent {
+    // Occurs when any aircraft shuts down its engines.
+    string initiator = 1;
+  }
+
+  // Occurs when a player takes direct control of a unit.
+  message PlayerEnterUnitEvent {
+    // The unit the player took control of.
+    string initiator = 1;
+  }
+
+  // Occurs when a player relieves direct control of a unit.
+  message PlayerLeaveUnitEvent {
+    // The unit the player relieves control of.
+    string initiator = 1;
+  }
+
+  // Occurs when a unit begins firing a machine gun- or autocannon-based weapon
+  // (weapons with a high rate of fire). Other weapons are handled by
+  // [ShotEvent].
+  message ShootingStartEvent {
+    // The unit that started firing.
+    string initiator = 1;
+  }
+
+  // Occurs when a unit stops firing a machine gun- or autocannon-based weapon.
+  // Event will always correspond with a [ShootingStartEvent] event.
+  message ShootingEndEvent {
+    // The unit that was shooting and has no stopped firing.
+    string initiator = 1;
+  }
+
+  // Occurs when marks get added to the mission by players or scripting
+  // functions.
+  message MarkAddEvent {
+    // The unit that added the mark.
+    string initiator = 1;
+    // The group the mark's visibility is restricted for.
+    uint64 group_id = 2;
+    // The coalition the mark's visibility is restricted for.
+    Coalition coalition = 3;
+    // The mark's id.
+    uint32 id = 4;
+    // The position the mark has been added at.
+    Position pos = 5;
+    // The mark's label.
+    string text = 6;
+  }
+
+  // Occurs when marks got changed.
+  message MarkChangeEvent {
+    // The unit that changed the mark.
+    string initiator = 1;
+    // The group the mark's visibility is restricted for.
+    uint64 group_id = 2;
+    // The coalition the mark's visibility is restricted for.
+    Coalition coalition = 3;
+    // The mark's id.
+    uint32 id = 4;
+    // The position of the changed mark.
+    Position pos = 5;
+    // The mark's label.
+    string text = 6;
+  }
+
+  // Occurs when marks get removed.
+  message MarkRemoveEvent {
+    // The unit that removed the mark.
+    string initiator = 1;
+    // The group the mark's visibility is restricted for.
+    uint64 group_id = 2;
+    // The coalition the mark's visibility is restricted for.
+    Coalition coalition = 3;
+    // The mark's id.
+    uint32 id = 4;
+    // The position the mark has been removed from.
+    Position pos = 5;
+    // The mark's label.
+    string text = 6;
+  }
+
+  // The event's mission time.
+  double time = 1;
+  oneof event {
+    ShotEvent shot = 4;
+    HitEvent hit = 5;
+    TakeoffEvent takeoff = 6;
+    LandEvent land = 7;
+    CrashEvent crash = 8;
+    EjectionEvent ejection = 9;
+    RefuelingEvent refueling = 10;
+    DeadEvent dead = 11;
+    PilotDeadEvent pilot_dead = 12;
+    BaseCaptureEvent base_capture = 13;
+    MissionStartEvent mission_start = 14;
+    MissionEndEvent mission_end = 15;
+    RefuelingStopEvent refueling_stop = 16;
+    BirthEvent birth = 17;
+    SystemFailureEvent system_failure = 18;
+    EngineStartupEvent engine_startup = 19;
+    EngineShutdownEvent engine_shutdown = 20;
+    PlayerEnterUnitEvent player_enter_unit = 21;
+    PlayerLeaveUnitEvent player_leave_unit = 22;
+    ShootingStartEvent shooting_start = 23;
+    ShootingEndEvent shooting_end = 24;
+    MarkAddEvent mark_add = 25;
+    MarkChangeEvent mark_change = 26;
+    MarkRemoveEvent mark_remove = 27;
+  }
 }
 
 service Mission {
   // https://wiki.hoggitworld.com/view/DCS_func_outText
-  rpc OutText (OutTextRequest) returns (OutTextResponse) {}
+  rpc OutText(OutTextRequest) returns (OutTextResponse) {}
 
   // https://wiki.hoggitworld.com/view/DCS_func_getUserFlag
-  rpc GetUserFlag (GetUserFlagRequest) returns (GetUserFlagResponse) {}
+  rpc GetUserFlag(GetUserFlagRequest) returns (GetUserFlagResponse) {}
 
   // https://wiki.hoggitworld.com/view/DCS_func_setUserFlag
-  rpc SetUserFlag (SetUserFlagRequest) returns (SetUserFlagResponse) {}
+  rpc SetUserFlag(SetUserFlagRequest) returns (SetUserFlagResponse) {}
+
+  rpc StreamEvents(StreamEventsRequest) returns (stream Event) {}
 }

--- a/proto/dcs.proto
+++ b/proto/dcs.proto
@@ -204,10 +204,12 @@ message Event {
   message MarkAddEvent {
     // The unit that added the mark.
     string initiator = 1;
-    // The group the mark's visibility is restricted for.
-    uint64 group_id = 2;
-    // The coalition the mark's visibility is restricted for.
-    Coalition coalition = 3;
+    oneof visibility {
+      // The group the mark's visibility is restricted for.
+      uint64 group_id = 2;
+      // The coalition the mark's visibility is restricted for.
+      Coalition coalition = 3;
+    }
     // The mark's id.
     uint32 id = 4;
     // The position the mark has been added at.
@@ -220,10 +222,12 @@ message Event {
   message MarkChangeEvent {
     // The unit that changed the mark.
     string initiator = 1;
-    // The group the mark's visibility is restricted for.
-    uint64 group_id = 2;
-    // The coalition the mark's visibility is restricted for.
-    Coalition coalition = 3;
+    oneof visibility {
+      // The group the mark's visibility is restricted for.
+      uint64 group_id = 2;
+      // The coalition the mark's visibility is restricted for.
+      Coalition coalition = 3;
+    }
     // The mark's id.
     uint32 id = 4;
     // The position of the changed mark.
@@ -236,10 +240,12 @@ message Event {
   message MarkRemoveEvent {
     // The unit that removed the mark.
     string initiator = 1;
-    // The group the mark's visibility is restricted for.
-    uint64 group_id = 2;
-    // The coalition the mark's visibility is restricted for.
-    Coalition coalition = 3;
+    oneof visibility {
+      // The group the mark's visibility is restricted for.
+      uint64 group_id = 2;
+      // The coalition the mark's visibility is restricted for.
+      Coalition coalition = 3;
+    }
     // The mark's id.
     uint32 id = 4;
     // The position the mark has been removed from.

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -96,7 +96,7 @@ mod tests {
     fn test_optional_field_deserialization() {
         let event: Event = serde_json::from_str(
             r#"{"time":4.2,"event":{"type":"markAdd","initiator":"Unit1",
-            "coalition":2,"id":42,"pos":{"x":1,"y":2,"z":3},"text":"Test"}}"#,
+            "coalition":2,"id":42,"pos":{"lat":1,"lon":2,"alt":3},"text":"Test"}}"#,
         )
         .unwrap();
         assert_eq!(
@@ -110,9 +110,9 @@ mod tests {
                     )),
                     id: 42,
                     pos: Some(event::Position {
-                        x: 1.0,
-                        y: 2.0,
-                        z: 3.0
+                        lat: 1.0,
+                        lon: 2.0,
+                        alt: 3.0
                     }),
                     text: "Test".to_string(),
                 })),

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -81,12 +81,41 @@ mod tests {
 
     #[test]
     fn test_event_deserialization() {
-        let event: Event = serde_json::from_str(r#"{"time":4.2,"missionStart":{}}"#).unwrap();
+        let event: Event =
+            serde_json::from_str(r#"{"time":4.2,"event":{"type":"missionStart"}}"#).unwrap();
         assert_eq!(
             event,
             Event {
                 time: 4.2,
                 event: Some(event::Event::MissionStart(event::MissionStartEvent {})),
+            }
+        );
+    }
+
+    #[test]
+    fn test_optional_field_deserialization() {
+        let event: Event = serde_json::from_str(
+            r#"{"time":4.2,"event":{"type":"markAdd","initiator":"Unit1",
+            "coalition":2,"id":42,"pos":{"x":1,"y":2,"z":3},"text":"Test"}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            event,
+            Event {
+                time: 4.2,
+                event: Some(event::Event::MarkAdd(event::MarkAddEvent {
+                    initiator: "Unit1".to_string(),
+                    visibility: Some(event::mark_add_event::Visibility::Coalition(
+                        event::Coalition::Blue.into()
+                    )),
+                    id: 42,
+                    pos: Some(event::Position {
+                        x: 1.0,
+                        y: 2.0,
+                        z: 3.0
+                    }),
+                    text: "Test".to_string(),
+                })),
             }
         );
     }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,6 +1,9 @@
+use std::pin::Pin;
+
 use dcs::mission_server::{Mission, MissionServer};
 use dcs::*;
 use dcs_module_ipc::IPC;
+use futures::{Stream, StreamExt};
 use tonic::transport::server::Router;
 use tonic::transport::{self, Server};
 use tonic::{Request, Response, Status};
@@ -10,12 +13,12 @@ pub mod dcs {
 }
 
 pub struct RPC {
-    ipc: IPC<usize>,
+    ipc: IPC<Event>,
 }
 
 impl RPC {
     pub fn builder(
-        ipc: IPC<usize>,
+        ipc: IPC<Event>,
     ) -> Router<MissionServer<RPC>, transport::server::Unimplemented> {
         Server::builder().add_service(MissionServer::new(RPC { ipc }))
     }
@@ -23,6 +26,9 @@ impl RPC {
 
 #[tonic::async_trait]
 impl Mission for RPC {
+    type StreamEventsStream =
+        Pin<Box<dyn Stream<Item = Result<Event, tonic::Status>> + Send + Sync + 'static>>;
+
     async fn out_text(
         &self,
         request: Request<OutTextRequest>,
@@ -32,7 +38,7 @@ impl Mission for RPC {
             .await
             .map_err(|err| Status::internal(err.to_string()))?;
 
-        Ok(Response::new(OutTextResponse { success: true }))
+        Ok(Response::new(OutTextResponse {}))
     }
 
     async fn get_user_flag(
@@ -56,6 +62,32 @@ impl Mission for RPC {
             .await
             .map_err(|err| Status::internal(err.to_string()))?;
 
-        Ok(Response::new(SetUserFlagResponse { success: true }))
+        Ok(Response::new(SetUserFlagResponse {}))
+    }
+
+    async fn stream_events(
+        &self,
+        _request: Request<StreamEventsRequest>,
+    ) -> Result<Response<Self::StreamEventsStream>, Status> {
+        Ok(Response::new(Box::pin(
+            self.ipc.events().await.map(|e| Ok(e)),
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::dcs::{event, Event};
+
+    #[test]
+    fn test_event_deserialization() {
+        let event: Event = serde_json::from_str(r#"{"time":4.2,"missionStart":{}}"#).unwrap();
+        assert_eq!(
+            event,
+            Event {
+                time: 4.2,
+                event: Some(event::Event::MissionStart(event::MissionStartEvent {})),
+            }
+        );
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,28 +1,28 @@
 use std::time::Duration;
 
+use crate::rpc::dcs::Event;
 use crate::rpc::RPC;
 use dcs_module_ipc::IPC;
 use futures::FutureExt;
 use tokio::sync::oneshot::Receiver;
-use tokio::time::delay_for;
+use tokio::time::sleep;
 use tonic::transport;
 
-#[tokio::main]
-pub async fn run(ipc: IPC<usize>, mut shutdown_signal: Receiver<()>) {
+pub async fn run(ipc: IPC<Event>, mut shutdown_signal: Receiver<()>) {
     loop {
         match try_run(ipc.clone(), &mut shutdown_signal).await {
             Ok(_) => break,
             Err(err) => {
                 log::error!("{}", err);
                 log::info!("Restarting gIPC Server in 10 seconds ...");
-                delay_for(Duration::from_secs(10)).await;
+                sleep(Duration::from_secs(10)).await;
             }
         }
     }
 }
 
 async fn try_run(
-    ipc: IPC<usize>,
+    ipc: IPC<Event>,
     shutdown_signal: &mut Receiver<()>,
 ) -> Result<(), transport::Error> {
     log::info!("Staring gRPC Server ...");


### PR DESCRIPTION
Implements the `StreamEvents` method which returns a stream of `Event`s.

Example:

```bash
$ grpcurl -plaintext -proto ./proto/dcs.proto -d "{}" [::1]:50051 dcs.Mission/StreamEvents
{
  "time": 28804.235,
  "playerEnterUnit": {
    "initiator": "Aerial-1-1"
  }
}
{
  "time": 28804.235,
  "birth": {
    "initiator": "Aerial-1-1"
  }
}
```

I've migrated the event handling from code I already had, so most of the events should work fine. Since there were still minor changes, I am planning to re-test most events to make sure (though there are always edge cases that we'll only catch by actually using the server eventually).

However, the main goal of this PR is to get feedback on the Lua and protobuf code (since I don't have a lot of previous experience with protobuf, so I might for example be doing the whole field numbering wrong) and agree on the RPC interface (naming, data structures, ...) - so feedback (including nitpicking) is welcome!