### PR TITLE
Add Unit.getRadar skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@
 make build
 ```
 
+You may need to use the following in powershell
+
+```
+$env:LUA_LIB_NAME="lua"
+$env:LUA_LIB=(Get-Item -Path ".\").FullName+"/lua/lua5.1/"
+$env:LUA_INC=(Get-Item -Path ".\").FullName+"/lua/lua5.1/include"
+cargo build
+```
+
 ### Mission Setup
 
 Add the following script to your mission (adjust the paths to match your repo location):

--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .field_attribute("dcs.Event.MarkChangeEvent.visibility", "#[serde(flatten)]")
         .field_attribute("dcs.Event.MarkRemoveEvent.visibility", "#[serde(flatten)]")
         .build_server(true)
-        .compile(&["proto/dcs.proto"], &["proto"])?;
+        .compile(&["protos/dcs_mission.proto"], &["protos"])?;
     Ok(())
 }

--- a/lua/grpc.lua
+++ b/lua/grpc.lua
@@ -30,6 +30,7 @@ end
 
 GRPC.methods = {}
 dofile(GRPC.basePath .. [[methods\trigger.lua]])
+dofile(GRPC.basePath .. [[methods\unit.lua]])
 
 --
 -- RPC request handler

--- a/lua/methods/trigger.lua
+++ b/lua/methods/trigger.lua
@@ -1,5 +1,6 @@
 --
 -- RPC trigger actions
+-- https://wiki.hoggitworld.com/view/DCS_singleton_trigger
 --
 
 GRPC.methods.outText = function(params)

--- a/lua/methods/unit.lua
+++ b/lua/methods/unit.lua
@@ -1,0 +1,58 @@
+--
+-- RPC unit actions
+-- https://wiki.hoggitworld.com/view/DCS_Class_Unit
+--
+
+local Unit = Unit
+local Object = Object
+local next = next 
+
+GRPC.methods.getRadar = function(params)
+  local unit = Unit.getByName(params.name)
+  if unit == nil then
+    return GRPC.error("Could not find unit with name '" .. params.name .. "'")
+  end
+    
+  local active, object = unit:getRadar() 
+  
+  if object == nil then
+    env.info("[GRPC]" .. params.name .. " has no radar target")
+    return GRPC.success({   
+      active = active
+    })
+  end
+  
+  env.info("[GRPC]" .. params.name .. "'s Target is " .. object:getCallsign() .. ", ID: " .. object:getID() .. ", Category: " .. object:getCategory() )
+   
+  local category = object:getCategory()
+  local grpc_hash = {}
+  local object_hash = {}
+  
+  if(category == Object.Category.UNIT) then
+    -- TODO, fill out the hash for this object
+    grpc_hash["unit"] = object_hash 
+  elseif(category == Object.Category.WEAPON) then
+    -- TODO, fill out the hash for this object
+    grpc_hash["weapon"] = object_hash 
+  elseif(category == Object.Category.STATIC) then
+    -- TODO, fill out the hash for this object
+    grpc_hash["static"] = object_hash 
+  elseif(category == Object.Category.BASE) then
+    -- TODO, fill out the hash for this object
+    grpc_hash["airbase"] = object_hash 
+  elseif(category == Object.Category.SCENERY) then
+    -- TODO, fill out the hash for this object
+    grpc_hash["scenery"] = object_hash 
+  elseif(category == Object.Category.Cargo) then
+    -- TODO, fill out the hash for this object
+    grpc_hash["cargo"] = object_hash 
+  else
+    env.info("[GRPC] Could not determine object category of object with ID: " .. object:getID() .. ", Category: " .. category)   
+    grpc_hash["object"] = {}   
+  end
+  
+  return GRPC.success({   
+    active = active,
+    target = grpc_hash 
+  })
+end

--- a/protos/common.proto
+++ b/protos/common.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+
+package dcs;
+
+enum ObjectCategory {
+  DUMMY = 0; // Proto must start at 0 but the category index starts at 1 so add a dummy value
+  UNIT = 1;
+  WEAPON = 2;
+  STATIC = 3;
+  SCENERY = 4;
+  BASE = 5;
+  CARGO = 6;
+}
+
+enum Coalition {
+  NEUTRAL = 0;
+  RED = 1;
+  BLUE = 2;
+}
+
+message Position {
+  double lat = 1;
+  double lon = 2;
+  double alt = 3; // in meters
+}
+
+message Object {
+}
+
+message Unit {
+}
+
+message Weapon {
+}
+
+message Static {
+}
+
+message Scenery {
+}
+
+message Airbase {
+}
+
+message Cargo {
+}

--- a/protos/dcs_mission.proto
+++ b/protos/dcs_mission.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+import "event_stream.proto";
+import "trigger.proto";
+import "unit.proto";
+
+package dcs;
+
+service Mission {
+  // https://wiki.hoggitworld.com/view/DCS_func_outText
+  rpc OutText(OutTextRequest) returns (OutTextResponse) {}
+
+  // https://wiki.hoggitworld.com/view/DCS_func_getUserFlag
+  rpc GetUserFlag(GetUserFlagRequest) returns (GetUserFlagResponse) {}
+
+  // https://wiki.hoggitworld.com/view/DCS_func_setUserFlag 
+  rpc SetUserFlag(SetUserFlagRequest) returns (SetUserFlagResponse) {}
+  
+  // https://wiki.hoggitworld.com/view/DCS_func_getRadar
+  rpc GetRadar(GetRadarRequest) returns (GetRadarResponse) {}
+
+  rpc StreamEvents(StreamEventsRequest) returns (stream Event) {}
+}

--- a/protos/event_stream.proto
+++ b/protos/event_stream.proto
@@ -1,60 +1,18 @@
 syntax = "proto3";
 
+import "common.proto";
+
 package dcs;
-
-message OutTextRequest {
-  string text = 1;
-  int32 display_time = 2;
-  bool clear_view = 3;
-}
-
-message OutTextResponse {}
-
-message GetUserFlagRequest {
-  string flag = 1;
-}
-
-message GetUserFlagResponse {
-  uint32 value = 1;
-}
-
-message SetUserFlagRequest {
-  string flag = 1;
-  uint32 value = 2;
-}
-
-message SetUserFlagResponse {}
 
 message StreamEventsRequest {}
 
 message Event {
-  enum ObjectCategory {
-    UNIT = 0;
-    WEAPON = 1;
-    STATIC = 2;
-    SCENERY = 3;
-    BASE = 4;
-    CARGO = 5;
-  }
-
-  enum Coalition {
-    NEUTRAL = 0;
-    RED = 1;
-    BLUE = 2;
-  }
-
   message Target {
     ObjectCategory category = 1;
     oneof target {
       uint64 id = 2;
       string name = 3;
     }
-  }
-
-  message Position {
-    double lat = 1;
-    double lon = 2;
-    double alt = 3; // in meters
   }
 
   // Occurs when a unit fires a weapon (but no machine gun- or autocannon-based
@@ -282,17 +240,4 @@ message Event {
     MarkChangeEvent mark_change = 26;
     MarkRemoveEvent mark_remove = 27;
   }
-}
-
-service Mission {
-  // https://wiki.hoggitworld.com/view/DCS_func_outText
-  rpc OutText(OutTextRequest) returns (OutTextResponse) {}
-
-  // https://wiki.hoggitworld.com/view/DCS_func_getUserFlag
-  rpc GetUserFlag(GetUserFlagRequest) returns (GetUserFlagResponse) {}
-
-  // https://wiki.hoggitworld.com/view/DCS_func_setUserFlag
-  rpc SetUserFlag(SetUserFlagRequest) returns (SetUserFlagResponse) {}
-
-  rpc StreamEvents(StreamEventsRequest) returns (stream Event) {}
 }

--- a/protos/trigger.proto
+++ b/protos/trigger.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package dcs;
+
+message OutTextRequest {
+  string text = 1;
+  int32 display_time = 2;
+  bool clear_view = 3;
+}
+
+message OutTextResponse {}
+
+message GetUserFlagRequest {
+  string flag = 1;
+}
+
+message GetUserFlagResponse {
+  uint32 value = 1;
+}
+
+message SetUserFlagRequest {
+  string flag = 1;
+  uint32 value = 2;
+}
+
+message SetUserFlagResponse {}

--- a/protos/unit.proto
+++ b/protos/unit.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+import "common.proto";
+
+package dcs;
+
+message GetRadarRequest {
+  string name = 1;
+}
+
+message GetRadarResponse {
+  bool active = 1;
+  oneof target {
+    Object object = 2;
+    Unit unit = 3;
+    Weapon weapon = 4;
+    Static static = 5;
+    Scenery scenery = 6;
+    Airbase airbase = 7;
+    Cargo cargo = 8;
+  }
+}

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -65,6 +65,18 @@ impl Mission for RPC {
         Ok(Response::new(SetUserFlagResponse {}))
     }
 
+    async fn get_radar(
+        &self,
+        request: Request<GetRadarRequest>,
+    ) -> Result<Response<GetRadarResponse>, Status> {
+        let res: GetRadarResponse = self
+            .ipc
+            .request("getRadar", Some(request.into_inner()))
+            .await
+            .map_err(|err| Status::internal(err.to_string()))?;
+        Ok(Response::new(res))
+    }
+
     async fn stream_events(
         &self,
         _request: Request<StreamEventsRequest>,
@@ -77,6 +89,8 @@ impl Mission for RPC {
 
 #[cfg(test)]
 mod tests {
+    use super::dcs::Coalition;
+    use super::dcs::Position;
     use super::dcs::{event, Event};
 
     #[test]
@@ -106,10 +120,10 @@ mod tests {
                 event: Some(event::Event::MarkAdd(event::MarkAddEvent {
                     initiator: "Unit1".to_string(),
                     visibility: Some(event::mark_add_event::Visibility::Coalition(
-                        event::Coalition::Blue.into()
+                        Coalition::Blue.into()
                     )),
                     id: 42,
-                    pos: Some(event::Position {
+                    pos: Some(Position {
                         lat: 1.0,
                         lon: 2.0,
                         alt: 3.0

--- a/src/server.rs
+++ b/src/server.rs
@@ -27,7 +27,7 @@ async fn try_run(
 ) -> Result<(), transport::Error> {
     log::info!("Staring gRPC Server ...");
 
-    let addr = "[::1]:50051".parse().unwrap();
+    let addr = "0.0.0.0:50051".parse().unwrap();
     RPC::builder(ipc)
         .serve_with_shutdown(addr, shutdown_signal.map(|_| ()))
         .await?;


### PR DESCRIPTION
I haven't actually tested that the `getRadar` works but the server
compiles so I wanted to run these changes by you first to see what you
think.

I switched from `proto` directory to `protos` directory since that appeared
to be the standard naming + it is multiple files.

Tested by calling with the ruby client I am working on at the same time.

----------


Add the skeleton code for the dcs `Unit.getRadar` method.

In doing so it became quickly apparent that one .proto file would get
unwieldy quickly so split it out into smaller files. I have created a
common file to hold the enums and objects I expect to be returned from
all manner of methods.

Although I split the .proto file I kept all the methods in the base
`dcs` protobuf package. Although there was a temptation to create
sub-packages I do not believe it would work well when dealing with
methods on objects that inherit since I do not believe the client cares
about which object the method is actually being called on.

This might change as I try to implement some methods from the object
hierarchy so it is best to experiment with this now since this changes
the generated code in both the server and the clients so we want to do
this before things get too painful to change.