### PR TITLE
Add fields for "Unit" object type

### DIFF
--- a/lua/exporters/object.lua
+++ b/lua/exporters/object.lua
@@ -1,0 +1,53 @@
+--
+-- Converts DCS tables in the Object hierarchy into tables suitable for
+-- serialization into GRPC responses
+-- Each exporter has an equivalent .proto Message defined and they must
+-- be kept in sync
+--
+
+local GRPC = GRPC
+local coord = coord
+
+local function toLatLonPosition(pos)
+  local lat, lon, alt = coord.LOtoLL(pos)
+  return {
+    lat = lat,
+    lon = lon,
+    alt = alt,
+  }
+end
+
+GRPC.exporters.unit = function(unit)
+  return {
+    id = unit:getID()
+    name = unit:getName()
+    callsign = unit:getCallsign()
+    coalition = unit:getCoalition();
+    type = unit:getTypeName()
+    position = toLatLonPosition(unit:getPoint())
+  }
+end
+
+GRPC.exporters.weapon = function(weapon)
+  return {}
+end
+
+GRPC.exporters.static = function(static)
+  return {}
+end
+
+GRPC.exporters.airbase = function(airbase)
+  return {}
+end
+
+GRPC.exporters.scenery = function(scenery)
+  return {}
+end
+
+GRPC.exporters.cargo = function(cargo)
+  return {}
+end
+
+GRPC.exporters.object = function(object)
+  return {}
+end

--- a/lua/grpc.lua
+++ b/lua/grpc.lua
@@ -9,6 +9,13 @@ grpc.start()
 local stopped = false
 
 --
+-- Export methods
+--
+
+GRPC.exporters = {}
+dofile(GRPC.basePath .. [[exporters\object.lua]])
+
+--
 -- Helper methods
 --
 

--- a/lua/methods/unit.lua
+++ b/lua/methods/unit.lua
@@ -5,7 +5,7 @@
 
 local Unit = Unit
 local Object = Object
-local next = next 
+local GRPC = GRPC
 
 GRPC.methods.getRadar = function(params)
   local unit = Unit.getByName(params.name)
@@ -16,43 +16,33 @@ GRPC.methods.getRadar = function(params)
   local active, object = unit:getRadar() 
   
   if object == nil then
-    env.info("[GRPC]" .. params.name .. " has no radar target")
     return GRPC.success({   
       active = active
     })
   end
-  
-  env.info("[GRPC]" .. params.name .. "'s Target is " .. object:getCallsign() .. ", ID: " .. object:getID() .. ", Category: " .. object:getCategory() )
    
   local category = object:getCategory()
-  local grpc_hash = {}
-  local object_hash = {}
+  local grpcTable = {}
   
   if(category == Object.Category.UNIT) then
-    -- TODO, fill out the hash for this object
-    grpc_hash["unit"] = object_hash 
+    grpcTable["unit"] = GRPC.exporters.unit(object) 
   elseif(category == Object.Category.WEAPON) then
-    -- TODO, fill out the hash for this object
-    grpc_hash["weapon"] = object_hash 
+    grpcTable["weapon"] = GRPC.exporters.weapon(object) 
   elseif(category == Object.Category.STATIC) then
-    -- TODO, fill out the hash for this object
-    grpc_hash["static"] = object_hash 
+    grpcTable["static"] = GRPC.exporters.static(object) 
   elseif(category == Object.Category.BASE) then
-    -- TODO, fill out the hash for this object
-    grpc_hash["airbase"] = object_hash 
+    grpcTable["airbase"] = GRPC.exporters.airbase(object) 
   elseif(category == Object.Category.SCENERY) then
-    -- TODO, fill out the hash for this object
-    grpc_hash["scenery"] = object_hash 
+    grpcTable["scenery"] = GRPC.exporters.scenery(object) 
   elseif(category == Object.Category.Cargo) then
-    -- TODO, fill out the hash for this object
-    grpc_hash["cargo"] = object_hash 
+    grpcTable["cargo"] = GRPC.exporters.cargo(object) 
   else
     env.info("[GRPC] Could not determine object category of object with ID: " .. object:getID() .. ", Category: " .. category)   
-    grpc_hash["object"] = {}   
+    grpcTable["object"] = GRPC.exporters.object(object)
   end
   
   return GRPC.success({   
     active = active,
-    target = grpc_hash 
+    target = grpcTable 
   })
 end

--- a/protos/common.proto
+++ b/protos/common.proto
@@ -24,10 +24,17 @@ message Position {
   double alt = 3; // in meters
 }
 
+// Returned if a sub-type listed below cannot be found
 message Object {
 }
 
 message Unit {
+  string id = 1;
+  string name = 2;
+  string callsign = 3;
+  Coalition coalition = 4;
+  string type = 5;
+  Position position = 6;
 }
 
 message Weapon {
@@ -44,3 +51,5 @@ message Airbase {
 
 message Cargo {
 }
+
+// End of Object subtypes


### PR DESCRIPTION
Add fields for the "Unit" object common type and return it as part of
the GetRadar call. This is a test to show that it works in a simple
request / response situation.

Adding the "Unit" object to the EventStream is out of scope for this
commit

---

Tested using the Ruby client

```ruby
client = Dcs::Grpc::Client.new(host: "192.168.1.25")
client.get_unit_radar("Blue Flight-2")
<Dcs::GetRadarRequest: name: "Blue Flight-2">
<Dcs::GetRadarResponse: active: true, unit: <Dcs::Unit: id: "22", name: "Red Flight-2", callsign: "103", coalition: :RED, type: "MiG-29S", position: <Dcs::Position: lat: 42.36043802598069, lon: 42.61754373339121, alt: 1996.1187744140625>>>
```