### PR TITLE
add support for various GRPC client error types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-dcs-module-ipc = "0.3"
+dcs-module-ipc = "0.4"
 futures = "0.3"
 log4rs = "1.0"
 log = "0.4"

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ dofile(GRPC.basePath .. [[grpc.lua]])
 Test the running server via:
 
 ```bash
-grpcurl -plaintext -proto ./proto/dcs.proto -d "{\"text\": \"Works!\", \"display_time\": 10, \"clear_view\": false}" [::1]:50051 dcs.Mission/OutText
+grpcurl -plaintext -import-path ./protos -proto ./protos/dcs_mission.proto -d "{\"text\": \"Works!\", \"display_time\": 10, \"clear_view\": false}" 127.0.0.1:50051 dcs.Mission/OutText
 ```
 
 or watch the mission event stream via:
 
 ```bash
-grpcurl -plaintext -proto ./proto/dcs.proto -d "{}" [::1]:50051 dcs.Mission/StreamEvents
+grpcurl -plaintext -import-path ./protos -proto ./protos/dcs_mission.proto -d "{}" 127.0.0.1:50051 dcs.Mission/StreamEvents
 ```

--- a/lua/grpc.lua
+++ b/lua/grpc.lua
@@ -27,7 +27,49 @@ end
 
 GRPC.error = function(msg)
   return {
-    error = msg
+    error = {
+      message = msg,
+    }
+  }
+end
+
+--- The client specified an invalid argument
+GRPC.errorInvalidArgument = function(msg)
+  return {
+    error = {
+      type = "INVALID_ARGUMENT",
+      message = msg,
+    }
+  }
+end
+
+--- Some requested entity was not found.
+GRPC.errorNotFound = function(msg)
+  return {
+    error = {
+      type = "NOT_FOUND",
+      message = msg,
+    }
+  }
+end
+
+--- The entity that a client attempted to create already exists.
+GRPC.errorAlreadyExists = function(msg)
+  return {
+    error = {
+      type = "ALREADY_EXISTS",
+      message = msg,
+    }
+  }
+end
+
+--- The operation is not implemented or is not supported/enabled in this service.
+GRPC.errorUnimplemented = function(msg)
+  return {
+    error = {
+      type = "UNIMPLEMENTED",
+      message = msg,
+    }
   }
 end
 

--- a/lua/methods/unit.lua
+++ b/lua/methods/unit.lua
@@ -10,7 +10,7 @@ local GRPC = GRPC
 GRPC.methods.getRadar = function(params)
   local unit = Unit.getByName(params.name)
   if unit == nil then
-    return GRPC.error("Could not find unit with name '" .. params.name .. "'")
+    return GRPC.errorNotFound("Could not find unit with name '" .. params.name .. "'")
   end
     
   local active, object = unit:getRadar() 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,10 +133,13 @@ fn next(lua: &Lua, callback: Function) -> LuaResult<bool> {
             }
 
             let result: LuaTable = callback.call((method.as_str(), params))?;
-            let error: Option<String> = result.get("error")?;
+            let error: Option<LuaTable> = result.get("error")?;
 
             if let Some(error) = error {
-                next.error(error);
+                let message: String = error.get("message")?;
+                let kind: Option<String> = error.get("type")?;
+
+                next.error(message, kind);
                 return Ok(true);
             }
 


### PR DESCRIPTION
This PR adds the possibility to define an error type when returning an error from a Lua handler. Those types are mapped to GRPC error types as suggested in https://github.com/DCS-gRPC/rust-server/pull/3#discussion_r598201052.

I hope you don't mind the removed trailing whitespaces (which my editor does automatically).

Example of `GetRadar` returning a `NotFound` now:

```
grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs_mission.proto -d "{\"name\": \"Whatever\"}" 127.0.0.1:50051 dcs.Mission/GetRadar
ERROR:
  Code: NotFound
  Message: Could not find unit with name 'Whatever'
```