### PR TITLE
Add DCT functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 !.github
 /target
 Cargo.lock
+scratchpad.txt
+grpcurl.exe

--- a/lua/grpc.lua
+++ b/lua/grpc.lua
@@ -81,6 +81,7 @@ GRPC.methods = {}
 dofile(GRPC.basePath .. [[methods\trigger.lua]])
 dofile(GRPC.basePath .. [[methods\unit.lua]])
 dofile(GRPC.basePath .. [[methods\world.lua]])
+dofile(GRPC.basePath .. [[methods\custom.lua]])
 
 --
 -- RPC request handler

--- a/lua/methods/custom.lua
+++ b/lua/methods/custom.lua
@@ -1,0 +1,11 @@
+--
+-- APIs for functions that are not built-in to the DCS Mission Scripting Environment 
+--
+
+GRPC.methods.requestMissionAssignment = function(params)
+    return GRPC.errorUnimplemented("This method is not implemented")
+end
+
+GRPC.methods.joinMission = function(params)
+    return GRPC.errorUnimplemented("This method is not implemented")
+end

--- a/protos/custom.proto
+++ b/protos/custom.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package dcs;
+
+message MissionAssignmentRequest {
+	string unit_name = 1;
+	string mission_type = 2;
+}
+
+message MissionAssignmentResponse {}
+
+message MissionJoinRequest {
+	string unit_name = 1;
+	int32 mission_code = 2;
+}
+
+message MissionJoinResponse {}

--- a/protos/dcs_mission.proto
+++ b/protos/dcs_mission.proto
@@ -4,6 +4,7 @@ import "event_stream.proto";
 import "trigger.proto";
 import "unit.proto";
 import "world.proto";
+import "custom.proto";
 
 package dcs;
 
@@ -22,6 +23,12 @@ service Mission {
 
   // https://wiki.hoggitworld.com/view/DCS_func_getAirbases
   rpc GetAirbases(GetAirbasesRequest) returns (GetAirbasesResponse) {}
+
+  // DCT Function
+  rpc RequestMissionAssignment(MissionAssignmentRequest) returns (MissionAssignmentResponse) {}
+
+  // DCT Function
+  rpc JoinMission(MissionJoinRequest) returns (MissionJoinResponse) {}
 
   rpc StreamEvents(StreamEventsRequest) returns (stream Event) {}
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -90,6 +90,23 @@ impl Mission for RPC {
         Ok(Response::new(res))
     }
 
+    async fn request_mission_assignment(
+        &self,
+        request: Request<MissionAssignmentRequest>,
+    ) -> Result<Response<MissionAssignmentResponse>, Status> {
+        self.notification("requestMissionAssignment", request)
+            .await?;
+        Ok(Response::new(MissionAssignmentResponse {}))
+    }
+
+    async fn join_mission(
+        &self,
+        request: Request<MissionJoinRequest>,
+    ) -> Result<Response<MissionJoinResponse>, Status> {
+        self.notification("joinMission", request).await?;
+        Ok(Response::new(MissionJoinResponse {}))
+    }
+
     async fn stream_events(
         &self,
         _request: Request<StreamEventsRequest>,


### PR DESCRIPTION
Add some DCT functions to allow for use on DCT framework using servers.

See commit message for implementation details. I am not sure what the best way to organise the .protos is yet so going for the simplest option (just adding a "custom" category) to make it easier to reorganise later when we have more APIs implemented which might suggest a better organisation scheme.

The general idea of these is that we can use DCS-gRPC to provide the generic'ish RPC methods but in the cases where we are not directly implementing a built-in ED DCS method we leave them unimplemented so that the servers can implement the methods how they like.

In this case the methods are implemented by the DCT framework in https://github.com/ricmzn/dct/blob/syria-at-war/src/dct/systems/overlordBotRPC.lua

I have updated the C# client with these definitions: https://github.com/DCS-gRPC/csharp-client

And an implementation in OverlordBot: https://gitlab.com/overlord-bot/srs-bot/-/commit/a6bfae4af0c878c4317b49849f85feb5f57244cf