### PR TITLE
Add Atmosphere Query APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ dofile(GRPC.basePath .. [[grpc.lua]])
 Test the running server via [grpcurl](https://github.com/fullstorydev/grpcurl): (Remove the `.exe` when running on Linux)
 
 ```bash
-grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs_mission.proto -d '{\"text\": \"Works!\", \"display_time\": 10, \"clear_view\": false}' 127.0.0.1:50051 dcs.Triggers/OutText
+grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs.proto -d '{\"text\": \"Works!\", \"display_time\": 10, \"clear_view\": false}' 127.0.0.1:50051 dcs.Triggers/OutText
 ```
 
 or watch the mission event stream via:
 
 ```bash
-grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs_mission.proto -d '{}' 127.0.0.1:50051 dcs.Mission/StreamEvents
+grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs.proto -d '{}' 127.0.0.1:50051 dcs.Mission/StreamEvents
 ```
 
 ### Troublshooting

--- a/lua/grpc.lua
+++ b/lua/grpc.lua
@@ -79,6 +79,7 @@ end
 
 GRPC.methods = {}
 dofile(GRPC.basePath .. [[methods\coalitions.lua]])
+dofile(GRPC.basePath .. [[methods\atmosphere.lua]])
 dofile(GRPC.basePath .. [[methods\trigger.lua]])
 dofile(GRPC.basePath .. [[methods\unit.lua]])
 dofile(GRPC.basePath .. [[methods\world.lua]])

--- a/lua/methods/atmosphere.lua
+++ b/lua/methods/atmosphere.lua
@@ -1,0 +1,56 @@
+--
+-- RPC atmosphere actions
+-- https://wiki.hoggitworld.com/view/DCS_singleton_atmosphere
+--
+
+local atmosphere = atmosphere
+local coord = coord
+local GRPC = GRPC
+
+local function convertWindResults(windvec3)
+  local direction = math.deg(math.atan2(windvec3.z, windvec3.x))
+  
+  if direction < 0 then
+    direction = direction + 360
+  end
+  
+  -- Convert TO direction to FROM direction. 
+  if direction > 180 then
+    direction = direction-180
+  else
+    direction = direction+180
+  end
+  
+  -- Calc 2D strength.
+  local strength = math.sqrt((windvec3.x)^2+(windvec3.z)^2)
+
+  return  {
+    heading = direction, -- Western style. Heading the wind is coming FROM
+    strength = strength -- m/s
+  }
+end
+
+GRPC.methods.getWind = function(params)
+  local point = coord.LLtoLO(params.position.lat, params.position.lon, params.position.alt)
+     
+  return GRPC.success(convertWindResults(atmosphere.getWind(point)))
+end
+
+GRPC.methods.getWindWithTurbulence = function(params)
+  local point = coord.LLtoLO(params.position.lat, params.position.lon, params.position.alt)
+     
+  return GRPC.success(convertWindResults(atmosphere.getWindWithTurbulence(point)))
+end
+
+GRPC.methods.getTemperatureAndPressure = function(params)
+  local point = coord.LLtoLO(params.position.lat, params.position.lon, params.position.alt)
+  
+  local temperature, pressure = atmosphere.getTemperatureAndPressure(point)
+
+  return GRPC.success(
+    {
+      temperature = temperature, -- Kelvin
+      pressure = pressure -- Pascals
+    }
+  )
+end

--- a/protos/atmosphere.proto
+++ b/protos/atmosphere.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+import "common.proto";
+
+package dcs;
+
+message AtmosphereRequest {
+	Position position = 1;
+}
+
+message GetWindResponse {
+	float heading = 1;
+	float strength = 2;
+}
+
+message GetTemperatureAndPressureResponse {
+	float temperature = 1;
+	float pressure = 2;
+}

--- a/protos/dcs.proto
+++ b/protos/dcs.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+import "atmosphere.proto";
 import "event_stream.proto";
 import "trigger.proto";
 import "unit.proto";
@@ -9,6 +10,17 @@ import "common.proto";
 import "coalitions.proto";
 
 package dcs;
+
+service Atmosphere {
+	// https://wiki.hoggitworld.com/view/DCS_func_getWind
+	rpc GetWind(AtmosphereRequest) returns (GetWindResponse) {}
+
+	// https://wiki.hoggitworld.com/view/DCS_func_getWindWithTurbulence
+	rpc GetWindWithTurbulence(AtmosphereRequest) returns (GetWindResponse) {}
+
+	// https://wiki.hoggitworld.com/view/DCS_func_getWindWithTurbulence
+	rpc GetTemperatureAndPressure(AtmosphereRequest) returns (GetTemperatureAndPressureResponse) {}
+}
 
 service Coalitions {
 	// https://wiki.hoggitworld.com/view/DCS_func_getPlayers

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,6 +1,7 @@
 use std::pin::Pin;
 
 use crate::shutdown::{AbortableStream, ShutdownHandle};
+use dcs::atmosphere_server::Atmosphere;
 use dcs::coalitions_server::Coalitions;
 use dcs::custom_server::Custom;
 use dcs::mission_server::Mission;
@@ -123,6 +124,34 @@ impl Triggers for RPC {
     ) -> Result<Response<EmptyResponse>, Status> {
         self.notification("removeMark", request).await?;
         Ok(Response::new(EmptyResponse {}))
+    }
+}
+
+#[tonic::async_trait]
+impl Atmosphere for RPC {
+    async fn get_wind(
+        &self,
+        request: Request<AtmosphereRequest>,
+    ) -> Result<Response<GetWindResponse>, Status> {
+        let res: GetWindResponse = self.request("getWind", request).await?;
+        Ok(Response::new(res))
+    }
+
+    async fn get_wind_with_turbulence(
+        &self,
+        request: Request<AtmosphereRequest>,
+    ) -> Result<Response<GetWindResponse>, Status> {
+        let res: GetWindResponse = self.request("getWindWithTurbulence", request).await?;
+        Ok(Response::new(res))
+    }
+
+    async fn get_temperature_and_pressure(
+        &self,
+        request: Request<AtmosphereRequest>,
+    ) -> Result<Response<GetTemperatureAndPressureResponse>, Status> {
+        let res: GetTemperatureAndPressureResponse =
+            self.request("getTemperatureAndPressure", request).await?;
+        Ok(Response::new(res))
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use crate::rpc::dcs;
 use crate::rpc::RPC;
 use crate::shutdown::ShutdownHandle;
+use dcs::atmosphere_server::AtmosphereServer;
 use dcs::coalitions_server::CoalitionsServer;
 use dcs::custom_server::CustomServer;
 use dcs::mission_server::MissionServer;
@@ -43,6 +44,7 @@ async fn try_run(
     let addr = "0.0.0.0:50051".parse().unwrap();
     let rpc = RPC::new(ipc, shutdown_signal.clone());
     Server::builder()
+        .add_service(AtmosphereServer::new(rpc.clone()))
         .add_service(CoalitionsServer::new(rpc.clone()))
         .add_service(CustomServer::new(rpc.clone()))
         .add_service(MissionServer::new(rpc.clone()))


### PR DESCRIPTION
Implement the 3 atmospheric APIs provided by the mission environment. I am sticking with:
* The metric units for the wind strength
* Using the western convention of the wind heading being where it is coming from, not where it is heading to.
* The DCS provided values for temperature and pressure (Kelvin and Pascals)

I am also not doing any rounding. Let the clients determine what level of accuracy they want.

Tested using grpcurl.

```plain
./grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs.proto -d '{\"position\": { \"lat\": 43.116012753760046, \"lon\": 41.96052007622479, \"alt\": 6089.67431640625 }}' 127.0.0.1:50051 dcs.Atmosphere/GetWind
{
  "direction": 240.22713,
  "speed": 9.941755
}                       
```
```plain
./grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs.proto -d '{\"position\": { \"lat\": 43.116012753760046, \"lon\": 41.96052007622479, \"alt\": 6089.67431640625 }}' 127.0.0.1:50051 dcs.Atmosphere/GetWindWithTurbulence
{
  "direction": 239.76268,
  "speed": 9.890662
}
```
```plain                                                                                                                                                                                                                   
./grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs.proto -d '{\"position\": { \"lat\": 43.116012753760046, \"lon\": 41.96052007622479, \"alt\": 6089.67431640625 }}' 127.0.0.1:50051 dcs.Atmosphere/GetTemperatureAndPressure
{
  "temperature": 253.56712,
  "pressure": 47322.81
}
```