### PR TITLE
Add MarkPoint management APIs

### DIFF
--- a/lua/methods/trigger.lua
+++ b/lua/methods/trigger.lua
@@ -19,3 +19,33 @@ GRPC.methods.setUserFlag = function(params)
   trigger.action.setUserFlag(params.flag, params.value)
   return GRPC.success(nil)
 end
+
+GRPC.methods.markToAll = function(params)
+  local point = coord.LLtoLO(params.position.lat, params.position.lon, params.position.alt)
+
+  trigger.action.markToAll(params.id, params.text, point, params.readOnly, params.message)
+
+  return GRPC.success(nil)
+end
+
+GRPC.methods.markToCoalition = function(params)
+  local point = coord.LLtoLO(params.position.lat, params.position.lon, params.position.alt)
+
+  trigger.action.markToCoalition(params.id, params.text, point, params.coalition, params.readOnly, params.message)
+
+  return GRPC.success(nil)
+end
+
+GRPC.methods.markToGroup = function(params)
+  local point = coord.LLtoLO(params.position.lat, params.position.lon, params.position.alt)
+
+  trigger.action.markToGroup(params.id, params.text, point, params.groupId, params.readOnly, params.message)
+
+  return GRPC.success(nil)
+end
+
+GRPC.methods.removeMark = function(params)
+  trigger.action.removeMark(params.id)
+
+  return GRPC.success(nil)
+end

--- a/protos/common.proto
+++ b/protos/common.proto
@@ -24,6 +24,8 @@ enum Coalition {
   BLUE = 2;
 }
 
+message EmptyResponse {}
+
 message Position {
   double lat = 1;
   double lon = 2;
@@ -31,8 +33,7 @@ message Position {
 }
 
 // Returned if a sub-type listed below cannot be found
-message Object {
-}
+message Object {}
 
 message Unit {
   uint32 id = 1;

--- a/protos/dcs.proto
+++ b/protos/dcs.proto
@@ -36,13 +36,25 @@ service Mission {
 
 service Triggers {
 	// https://wiki.hoggitworld.com/view/DCS_func_outText
-	rpc OutText(OutTextRequest) returns (OutTextResponse) {}
+	rpc OutText(OutTextRequest) returns (EmptyResponse) {}
 
 	// https://wiki.hoggitworld.com/view/DCS_func_getUserFlag
 	rpc GetUserFlag(GetUserFlagRequest) returns (GetUserFlagResponse) {}
 
 	// https://wiki.hoggitworld.com/view/DCS_func_setUserFlag
-	rpc SetUserFlag(SetUserFlagRequest) returns (SetUserFlagResponse) {}
+	rpc SetUserFlag(SetUserFlagRequest) returns (EmptyResponse) {}
+
+	// https://wiki.hoggitworld.com/view/DCS_func_markToAll
+	rpc MarkToAll(MarkToAllRequest) returns (EmptyResponse) {}
+
+	// https://wiki.hoggitworld.com/view/DCS_func_markToCoalition
+	rpc MarkToCoalition(MarkToCoalitionRequest) returns (EmptyResponse) {}
+
+	// https://wiki.hoggitworld.com/view/DCS_func_markToGroup
+	rpc MarkToGroup(MarkToGroupRequest) returns (EmptyResponse) {}
+
+	// https://wiki.hoggitworld.com/view/DCS_func_removeMark
+	rpc RemoveMark(RemoveMarkRequest) returns (EmptyResponse) {}
 }
 
 service Units {

--- a/protos/trigger.proto
+++ b/protos/trigger.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+import "common.proto";
+
 package dcs;
 
 message OutTextRequest {
@@ -7,8 +9,6 @@ message OutTextRequest {
   int32 display_time = 2;
   bool clear_view = 3;
 }
-
-message OutTextResponse {}
 
 message GetUserFlagRequest {
   string flag = 1;
@@ -23,4 +23,32 @@ message SetUserFlagRequest {
   uint32 value = 2;
 }
 
-message SetUserFlagResponse {}
+message MarkToAllRequest {
+	uint32 id = 1;
+	string text = 2;
+	Position position = 3;
+	bool readOnly = 4;
+	string message = 5;
+}
+
+message MarkToCoalitionRequest {
+	uint32 id = 1;
+	string text = 2;
+	Position position = 3;
+	Coalition coalition = 4;
+	bool readOnly = 5;
+	string message = 6;
+}
+
+message MarkToGroupRequest {
+	uint32 id = 1;
+	string text = 2;
+	Position position = 3;
+	uint32 groupId = 4;
+	bool readOnly = 5;
+	string message = 6;
+}
+
+message RemoveMarkRequest {
+	uint32 id = 1;
+}

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -72,9 +72,9 @@ impl Triggers for RPC {
     async fn out_text(
         &self,
         request: Request<OutTextRequest>,
-    ) -> Result<Response<OutTextResponse>, Status> {
+    ) -> Result<Response<EmptyResponse>, Status> {
         self.notification("outText", request).await?;
-        Ok(Response::new(OutTextResponse {}))
+        Ok(Response::new(EmptyResponse {}))
     }
 
     async fn get_user_flag(
@@ -88,9 +88,41 @@ impl Triggers for RPC {
     async fn set_user_flag(
         &self,
         request: Request<SetUserFlagRequest>,
-    ) -> Result<Response<SetUserFlagResponse>, Status> {
+    ) -> Result<Response<EmptyResponse>, Status> {
         self.notification("setUserFlag", request).await?;
-        Ok(Response::new(SetUserFlagResponse {}))
+        Ok(Response::new(EmptyResponse {}))
+    }
+
+    async fn mark_to_all(
+        &self,
+        request: Request<MarkToAllRequest>,
+    ) -> Result<Response<EmptyResponse>, Status> {
+        self.notification("markToAll", request).await?;
+        Ok(Response::new(EmptyResponse {}))
+    }
+
+    async fn mark_to_coalition(
+        &self,
+        request: Request<MarkToCoalitionRequest>,
+    ) -> Result<Response<EmptyResponse>, Status> {
+        self.notification("markToCoalition", request).await?;
+        Ok(Response::new(EmptyResponse {}))
+    }
+
+    async fn mark_to_group(
+        &self,
+        request: Request<MarkToGroupRequest>,
+    ) -> Result<Response<EmptyResponse>, Status> {
+        self.notification("markToGroup", request).await?;
+        Ok(Response::new(EmptyResponse {}))
+    }
+
+    async fn remove_mark(
+        &self,
+        request: Request<RemoveMarkRequest>,
+    ) -> Result<Response<EmptyResponse>, Status> {
+        self.notification("removeMark", request).await?;
+        Ok(Response::new(EmptyResponse {}))
     }
 }
 


### PR DESCRIPTION
Add APIs that allows for managing MarkPoints in the mission environment.

Tested using grpcurl. Examples below

```plain
./grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs.proto -d '{\"id\": 14001, \"text\": \"Scripted markpoint\", \"position\": { \"lat\": 43.116012753760046, \"lon\": 41.96052007622479, \"alt\": 6089.67431640625 }, \"coalition\": 2, \"readOnly\": false, \"message\": \"\"}' 127.0.0.1:50051 dcs.Triggers/MarkToCoalition
{}
```

```plain
./grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs.proto -d '{\"id\": 14001}' 127.0.0.1:50051 dcs.Triggers/RemoveMark
{}
```