### PR TITLE
Add Coalition.GetPlayers API

### DIFF
--- a/lua/grpc.lua
+++ b/lua/grpc.lua
@@ -78,6 +78,7 @@ end
 --
 
 GRPC.methods = {}
+dofile(GRPC.basePath .. [[methods\coalitions.lua]])
 dofile(GRPC.basePath .. [[methods\trigger.lua]])
 dofile(GRPC.basePath .. [[methods\unit.lua]])
 dofile(GRPC.basePath .. [[methods\world.lua]])

--- a/lua/methods/coalitions.lua
+++ b/lua/methods/coalitions.lua
@@ -1,0 +1,19 @@
+--
+-- RPC unit actions
+-- https://wiki.hoggitworld.com/view/DCS_singleton_coalition
+--
+
+local GRPC = GRPC
+local coalition = coalition
+
+GRPC.methods.getPlayers = function(params)
+  local units = coalition.getPlayers(params.coalition)
+
+  result = {}
+
+  for i, unit in ipairs(units) do
+    result[i] = GRPC.exporters.unit(unit)
+  end
+  return GRPC.success({units = result})
+
+end

--- a/protos/coalitions.proto
+++ b/protos/coalitions.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+import "common.proto";
+
+package dcs;
+
+message GetPlayersRequest {
+	Coalition coalition = 1;
+}
+
+message GetPlayersResponse {
+	repeated Unit units = 1;
+}

--- a/protos/dcs.proto
+++ b/protos/dcs.proto
@@ -5,12 +5,14 @@ import "trigger.proto";
 import "unit.proto";
 import "world.proto";
 import "custom.proto";
+import "common.proto";
+import "coalitions.proto";
 
 package dcs;
 
 service Coalitions {
-	// https://wiki.hoggitworld.com/view/DCS_func_getAirbases
-	rpc GetAirbases(GetAirbasesRequest) returns (GetAirbasesResponse) {}
+	// https://wiki.hoggitworld.com/view/DCS_func_getPlayers
+	rpc GetPlayers(GetPlayersRequest) returns (GetPlayersResponse) {}
 }
 
 service Custom {
@@ -46,4 +48,9 @@ service Triggers {
 service Units {
 	// https://wiki.hoggitworld.com/view/DCS_func_getRadar
 	rpc GetRadar(GetRadarRequest) returns (GetRadarResponse) {}
+}
+
+service World {
+	// https://wiki.hoggitworld.com/view/DCS_func_getAirbases
+	rpc GetAirbases(GetAirbasesRequest) returns (GetAirbasesResponse) {}
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -6,6 +6,7 @@ use dcs::custom_server::Custom;
 use dcs::mission_server::Mission;
 use dcs::triggers_server::Triggers;
 use dcs::units_server::Units;
+use dcs::world_server::World;
 use dcs::*;
 use dcs_module_ipc::IPC;
 use futures_util::{Stream, StreamExt};
@@ -94,12 +95,23 @@ impl Triggers for RPC {
 }
 
 #[tonic::async_trait]
-impl Coalitions for RPC {
+impl World for RPC {
     async fn get_airbases(
         &self,
         request: Request<GetAirbasesRequest>,
     ) -> Result<Response<GetAirbasesResponse>, Status> {
         let res: GetAirbasesResponse = self.request("getAirbases", request).await?;
+        Ok(Response::new(res))
+    }
+}
+
+#[tonic::async_trait]
+impl Coalitions for RPC {
+    async fn get_players(
+        &self,
+        request: Request<GetPlayersRequest>,
+    ) -> Result<Response<GetPlayersResponse>, Status> {
+        let res: GetPlayersResponse = self.request("getPlayers", request).await?;
         Ok(Response::new(res))
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,6 +8,7 @@ use dcs::custom_server::CustomServer;
 use dcs::mission_server::MissionServer;
 use dcs::triggers_server::TriggersServer;
 use dcs::units_server::UnitsServer;
+use dcs::world_server::WorldServer;
 use dcs::*;
 use dcs_module_ipc::IPC;
 use futures_util::FutureExt;
@@ -46,7 +47,8 @@ async fn try_run(
         .add_service(CustomServer::new(rpc.clone()))
         .add_service(MissionServer::new(rpc.clone()))
         .add_service(TriggersServer::new(rpc.clone()))
-        .add_service(UnitsServer::new(rpc))
+        .add_service(UnitsServer::new(rpc.clone()))
+        .add_service(WorldServer::new(rpc))
         .serve_with_shutdown(addr, after_shutdown.map(|_| ()))
         .await?;
 


### PR DESCRIPTION
Add the API that allows us to get all the players in a coalition and
what unit they are in.

Once this and the other PRs are merged I will go through everything and normalise the pluralization in filenames etc.

```plain
./grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs.proto -d '{\"coalition\": 2}' 127.0.0.1:50051 dcs.Coalitions/GetPlayers
"units": [
  {
    "id": 1,
    "name": "Aerial-1-1",
    "callsign": "Enfield11",
    "coalition": "BLUE",
    "type": "FA-18C_hornet",
    "position": {
      "lat": 42.18262219221839,
      "lon": 42.476887902005345,
      "alt": 46.840728759765625
    },
    "playerName": "New callsign"
  }
]
```

```plain
./grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs.proto -d '{\"coalition\": 2}' 127.0.0.1:50051 dcs.World/GetAirbases
{
  "airbases": [
    {
      "name": "Kutaisi",
      "callsign": "Kutaisi",
      "coalition": "BLUE",
      "position": {
        "lat": 42.17915393768963,
        "lon": 42.49568407740014,
        "alt": 45.010047912597656
      },
      "displayName": "Kutaisi"
    },
    {
      "name": "Static Gas platform-1",
      "coalition": "BLUE",
      "position": {
        "lat": 43.30681789227776,
        "lon": 40.137562320898745,
        "alt": 1
      },
      "category": "SHIP"
    },
    {
      "name": "Static Oil rig-1",
      "coalition": "BLUE",
      "position": {
        "lat": 43.25817054521245,
        "lon": 40.19027736423267,
        "alt": 1
      },
      "category": "SHIP"
    },
    {
      "id": 27,
      "name": "Naval-1-1",
      "coalition": "BLUE",
      "position": {
        "lat": 44.29092381793492,
        "lon": 38.14214298210177,
        "alt": -2.2181286112754606e-05
      },
      "category": "SHIP",
      "displayName": "CVN-73 George Washington"
    }
  ]
}
```