### PR TITLE
Add World.getMarkPanels API

### DIFF
--- a/lua/exporters/object.lua
+++ b/lua/exporters/object.lua
@@ -69,3 +69,23 @@ end
 GRPC.exporters.object = function(object)
   return {}
 end
+
+GRPC.exporters.markPanel = function(markPanel)
+  local mp = {
+    id = markPanel.idx, 
+    time = markPanel.time,
+    initiator = GRPC.exporters.unit(markPanel.initiator),
+    text = markPanel.text,
+    position = toLatLonPosition(markPanel.pos)
+  }
+
+  if (markPanel.coalition >= 0 and markPanel.coalition <= 2) then
+  	mp["coalition"] = markPanel.coalition;
+  end
+
+  if (markPanel.groupID > 0) then
+  	mp["groupId"] = markPanel.groupID;
+  end
+
+  return mp
+end

--- a/lua/exporters/object.lua
+++ b/lua/exporters/object.lua
@@ -8,15 +8,6 @@
 local GRPC = GRPC
 local coord = coord
 
-local function toLatLonPosition(pos)
-  local lat, lon, alt = coord.LOtoLL(pos)
-  return {
-    lat = lat,
-    lon = lon,
-    alt = alt,
-  }
-end
-
 GRPC.exporters.unit = function(unit)
   return {
     id = tonumber(unit:getID()),
@@ -24,7 +15,7 @@ GRPC.exporters.unit = function(unit)
     callsign = unit:getCallsign(),
     coalition = unit:getCoalition(),
     type = unit:getTypeName(),
-    position = toLatLonPosition(unit:getPoint()),
+    position = GRPC.toLatLonPosition(unit:getPoint()),
     playerName = unit:getPlayerName()
   }
 end
@@ -33,7 +24,7 @@ GRPC.exporters.weapon = function(weapon)
   return {
     id = tonumber(weapon:getName()),
     type = weapon:getTypeName(),
-    position = toLatLonPosition(weapon:getPoint()),
+    position = GRPC.toLatLonPosition(weapon:getPoint()),
   }
 end
 
@@ -48,7 +39,7 @@ GRPC.exporters.airbase = function(airbase)
     coalition = airbase:getCoalition(),
     category = airbase:getDesc()['category'],
     displayName = airbase:getDesc()['displayName'],
-    position = toLatLonPosition(airbase:getPoint())
+    position = GRPC.toLatLonPosition(airbase:getPoint())
   }
 
   if airbase:getUnit() then
@@ -76,7 +67,7 @@ GRPC.exporters.markPanel = function(markPanel)
     time = markPanel.time,
     initiator = GRPC.exporters.unit(markPanel.initiator),
     text = markPanel.text,
-    position = toLatLonPosition(markPanel.pos)
+    position = GRPC.toLatLonPosition(markPanel.pos)
   }
 
   if (markPanel.coalition >= 0 and markPanel.coalition <= 2) then

--- a/lua/methods/world.lua
+++ b/lua/methods/world.lua
@@ -27,3 +27,15 @@ GRPC.methods.getAirbases = function(params)
   end
   return GRPC.success({airbases = result})
 end
+
+GRPC.methods.getMarkPanels = function(params)
+  markPanels = world.getMarkPanels()
+
+  local result = {}
+
+  for i, markPanel in ipairs(markPanels) do
+    result[i] = GRPC.exporters.markPanel(markPanel)
+  end
+
+  return GRPC.success({markPanels = result})
+end

--- a/protos/common.proto
+++ b/protos/common.proto
@@ -83,3 +83,13 @@ message Target {
 }
 
 // End of Object subtypes
+
+message MarkPanel {
+	uint32 id = 1; 
+	double time = 2; // I have no idea what this time value means
+	Unit initiator = 3;
+	optional Coalition coalition = 4;
+	optional uint32 group_id = 5;
+	optional string text = 6;
+	Position position = 7;
+}

--- a/protos/dcs.proto
+++ b/protos/dcs.proto
@@ -95,4 +95,7 @@ service Units {
 service World {
 	// https://wiki.hoggitworld.com/view/DCS_func_getAirbases
 	rpc GetAirbases(GetAirbasesRequest) returns (GetAirbasesResponse) {}
+
+	// https://wiki.hoggitworld.com/view/DCS_func_getMarkPanels
+	rpc GetMarkPanels(GetMarkPanelsRequest) returns (GetMarkPanelsResponse) {}
 }

--- a/protos/world.proto
+++ b/protos/world.proto
@@ -11,3 +11,9 @@ message GetAirbasesRequest {
 message GetAirbasesResponse {
   repeated Airbase airbases = 1;
 }
+
+message GetMarkPanelsRequest {}
+
+message GetMarkPanelsResponse {
+	repeated MarkPanel mark_panels = 1;
+}

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -212,6 +212,14 @@ impl World for RPC {
         let res: GetAirbasesResponse = self.request("getAirbases", request).await?;
         Ok(Response::new(res))
     }
+
+    async fn get_mark_panels(
+        &self,
+        request: Request<GetMarkPanelsRequest>,
+    ) -> Result<Response<GetMarkPanelsResponse>, Status> {
+        let res: GetMarkPanelsResponse = self.request("getMarkPanels", request).await?;
+        Ok(Response::new(res))
+    }
 }
 
 #[tonic::async_trait]


### PR DESCRIPTION
Add the World.getMarkPanels API so that we can implemented all the
MarkPanel APIs.

I have only tested in single player where it appears that the initiator
is _always_ the player even if the MarkPoint was created via scripting.

It also looks like, in SP at least, that "MarkToAll" API will result in
the markpoint being the "Blue" coalition.

I haven't yet had the opportunity to test on an MP server since it is not as easy as SP. Not sure if you prefer to hold off on merging until that is done. 
 
 ```plain
./grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs.proto -d '{}' 127.0.0.1:50051 dcs.World/GetMarkPanels
{
	"markPanels": [{
		"id": 1301,
		"time": 28916,
		"initiator": {
			"id": 1,
			"name": "Aerial-1-1",
			"callsign": "Enfield11",
			"coalition": "BLUE",
			"type": "FA-18C_hornet",
			"position": {
				"lat": 42.18262219221839,
				"lon": 42.476887902005345,
				"alt": 46.84111404418945
			},
			"playerName": "New callsign"
		},
		"coalition": "RED",
		"groupID": 4294967295,
		"text": "Scripted markpoint",
		"position": {
			"lat": 43.116012753760046,
			"lon": 41.96052007622479,
			"alt": 2683.032958984375
		}
	}, {
		"id": 13000,
		"time": 28835,
		"initiator": {
			"id": 1,
			"name": "Aerial-1-1",
			"callsign": "Enfield11",
			"coalition": "BLUE",
			"type": "FA-18C_hornet",
			"position": {
				"lat": 42.18262219221839,
				"lon": 42.476887902005345,
				"alt": 46.84111404418945
			},
			"playerName": "New callsign"
		},
		"groupID": 4294967295,
		"text": "Scripted markpoint",
		"position": {
			"lat": 43.116012753760046,
			"lon": 41.96052007622479,
			"alt": 2683.032958984375
		}
	}]
}
```