### PR TITLE
Add more trigger APIs

### DIFF
--- a/lua/methods/trigger.lua
+++ b/lua/methods/trigger.lua
@@ -9,6 +9,18 @@ GRPC.methods.outText = function(params)
   return GRPC.success(nil)
 end
 
+GRPC.methods.outTextForCoalition = function(params)
+  trigger.action.outTextForCoalition(params.coalition, params.text, params.displayTime, params.clearView)
+
+  return GRPC.success(nil)
+end
+
+GRPC.methods.outTextForGroup = function(params)
+  trigger.action.outTextForGroup(params.groupId, params.text, params.displayTime, params.clearView)
+
+  return GRPC.success(nil)
+end
+
 GRPC.methods.getUserFlag = function(params)
   return GRPC.success({
     value = trigger.misc.getUserFlag(params.flag),
@@ -46,6 +58,38 @@ end
 
 GRPC.methods.removeMark = function(params)
   trigger.action.removeMark(params.id)
+
+  return GRPC.success(nil)
+end
+
+GRPC.methods.explosion = function(params)
+  local point = coord.LLtoLO(params.position.lat, params.position.lon, params.position.alt)
+
+  trigger.action.explosion(point, params.power)
+
+  return GRPC.success(nil)
+end
+
+GRPC.methods.smoke = function(params)
+  local point = coord.LLtoLO(params.position.lat, params.position.lon, params.position.alt)
+
+  trigger.action.smoke(point, params.color)
+
+  return GRPC.success(nil)
+end
+
+GRPC.methods.illuminationBomb = function(params)
+  local point = coord.LLtoLO(params.position.lat, params.position.lon, params.position.alt)
+
+  trigger.action.illuminationBomb(point, params.power)
+
+  return GRPC.success(nil)
+end
+
+GRPC.methods.signalFlare = function(params)
+  local point = coord.LLtoLO(params.position.lat, params.position.lon, params.position.alt)
+
+  trigger.action.signalFlare(point, params.color, params.azimuth)
 
   return GRPC.success(nil)
 end

--- a/protos/common.proto
+++ b/protos/common.proto
@@ -42,7 +42,7 @@ message Unit {
   Coalition coalition = 4;
   string type = 5;
   Position position = 6;
-  optional string playerName = 7;
+  optional string player_name = 7;
 }
 
 message Weapon {

--- a/protos/dcs.proto
+++ b/protos/dcs.proto
@@ -38,6 +38,12 @@ service Triggers {
 	// https://wiki.hoggitworld.com/view/DCS_func_outText
 	rpc OutText(OutTextRequest) returns (EmptyResponse) {}
 
+	// https://wiki.hoggitworld.com/view/DCS_func_outTextForCoalition
+	rpc OutTextForCoalition(OutTextForCoalitionRequest) returns (EmptyResponse) {}
+
+	// https://wiki.hoggitworld.com/view/DCS_func_outTextForGroup
+	rpc OutTextForGroup(OutTextForGroupRequest) returns (EmptyResponse) {}
+
 	// https://wiki.hoggitworld.com/view/DCS_func_getUserFlag
 	rpc GetUserFlag(GetUserFlagRequest) returns (GetUserFlagResponse) {}
 
@@ -55,6 +61,18 @@ service Triggers {
 
 	// https://wiki.hoggitworld.com/view/DCS_func_removeMark
 	rpc RemoveMark(RemoveMarkRequest) returns (EmptyResponse) {}
+
+	// https://wiki.hoggitworld.com/view/DCS_func_explosion
+	rpc Explosion(ExplosionRequest) returns (EmptyResponse) {}
+
+	// https://wiki.hoggitworld.com/view/DCS_func_smoke
+	rpc Smoke(SmokeRequest) returns (EmptyResponse) {}
+
+	// https://wiki.hoggitworld.com/view/DCS_func_illuminationBomb
+	rpc IlluminationBomb(IlluminationBombRequest) returns (EmptyResponse) {}
+
+	// https://wiki.hoggitworld.com/view/DCS_func_signalFlare
+	rpc SignalFlare(SignalFlareRequest) returns (EmptyResponse) {}
 }
 
 service Units {

--- a/protos/trigger.proto
+++ b/protos/trigger.proto
@@ -41,7 +41,7 @@ message MarkToAllRequest {
 	uint32 id = 1;
 	string text = 2;
 	Position position = 3;
-	bool readOnly = 4;
+	bool read_only = 4;
 	string message = 5;
 }
 
@@ -58,8 +58,8 @@ message MarkToGroupRequest {
 	uint32 id = 1;
 	string text = 2;
 	Position position = 3;
-	uint32 groupId = 4;
-	bool readOnly = 5;
+	uint32 group_id = 4;
+	bool read_only = 5;
 	string message = 6;
 }
 

--- a/protos/trigger.proto
+++ b/protos/trigger.proto
@@ -10,6 +10,20 @@ message OutTextRequest {
   bool clear_view = 3;
 }
 
+message OutTextForCoalitionRequest {
+	string text = 1;
+	int32 display_time = 2;
+	bool clear_view = 3;
+	Coalition coalition = 4;
+}
+
+message OutTextForGroupRequest {
+	string text = 1;
+	int32 display_time = 2;
+	bool clear_view = 3;
+	uint32 groupId = 4;
+}
+
 message GetUserFlagRequest {
   string flag = 1;
 }
@@ -51,4 +65,44 @@ message MarkToGroupRequest {
 
 message RemoveMarkRequest {
 	uint32 id = 1;
+}
+
+message ExplosionRequest {
+	Position position = 1;
+	uint32 power = 2;
+}
+
+message SmokeRequest {
+  // Putting this inside the request because we cannot
+  // have the same enum value in the same package.
+  enum SmokeColor {
+    GREEN = 0;
+    RED = 1;
+    WHITE = 2;
+    ORANGE = 3;
+    BLUE = 4;
+  }
+
+  Position position = 1;
+  SmokeColor color = 2;
+}
+
+message IlluminationBombRequest {
+  Position position = 1;
+  uint32 power = 2;
+}
+
+message SignalFlareRequest {
+	// Putting this inside the request because we cannot
+	// have the same enum value in the same package.
+	enum FlareColor {
+		GREEN = 0;
+		RED = 1;
+		WHITE = 2;
+		YELLOW = 3;
+	}
+
+	Position position = 1;
+	FlareColor color = 2;
+	uint32 azimuth = 3;
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -77,6 +77,22 @@ impl Triggers for RPC {
         Ok(Response::new(EmptyResponse {}))
     }
 
+    async fn out_text_for_coalition(
+        &self,
+        request: Request<OutTextForCoalitionRequest>,
+    ) -> Result<Response<EmptyResponse>, Status> {
+        self.notification("outTextForCoalition", request).await?;
+        Ok(Response::new(EmptyResponse {}))
+    }
+
+    async fn out_text_for_group(
+        &self,
+        request: Request<OutTextForGroupRequest>,
+    ) -> Result<Response<EmptyResponse>, Status> {
+        self.notification("outTextForGroup", request).await?;
+        Ok(Response::new(EmptyResponse {}))
+    }
+
     async fn get_user_flag(
         &self,
         request: Request<GetUserFlagRequest>,
@@ -122,6 +138,38 @@ impl Triggers for RPC {
         request: Request<RemoveMarkRequest>,
     ) -> Result<Response<EmptyResponse>, Status> {
         self.notification("removeMark", request).await?;
+        Ok(Response::new(EmptyResponse {}))
+    }
+
+    async fn explosion(
+        &self,
+        request: Request<ExplosionRequest>,
+    ) -> Result<Response<EmptyResponse>, Status> {
+        self.notification("explosion", request).await?;
+        Ok(Response::new(EmptyResponse {}))
+    }
+
+    async fn smoke(
+        &self,
+        request: Request<SmokeRequest>,
+    ) -> Result<Response<EmptyResponse>, Status> {
+        self.notification("smoke", request).await?;
+        Ok(Response::new(EmptyResponse {}))
+    }
+
+    async fn illumination_bomb(
+        &self,
+        request: Request<IlluminationBombRequest>,
+    ) -> Result<Response<EmptyResponse>, Status> {
+        self.notification("illuminationBomb", request).await?;
+        Ok(Response::new(EmptyResponse {}))
+    }
+
+    async fn signal_flare(
+        &self,
+        request: Request<SignalFlareRequest>,
+    ) -> Result<Response<EmptyResponse>, Status> {
+        self.notification("signalFlare", request).await?;
         Ok(Response::new(EmptyResponse {}))
     }
 }


### PR DESCRIPTION
Add OutText commands for coalitions and groups. I have not added
"ForCountry" because I have never seen it used and it requires creating
a country Enum which is a lot of tedious typing.

Also add the APIs for the pretty visual triggers: Signal Flares, Smoke,
Illumination Bombs and EXPLOSIONS.

Tested in-game (and it was very pretty)