### PR TITLE
implement repl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,10 @@ version = "0.1.0"
 authors = ["Markus Ast <m@rkusa.st>"]
 license = "AGPL-3.0-or-later"
 edition = "2018"
+resolver = "2"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 dcs-module-ipc = "0.5"
@@ -18,6 +19,7 @@ once_cell = "1.4.0"
 pin-project = "1.0"
 prost = "0.7"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.0", features = ["rt-multi-thread", "time", "sync"] }
 tokio-stream = "0.1"

--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .field_attribute("dcs.Event.MarkChangeEvent.visibility", "#[serde(flatten)]")
         .field_attribute("dcs.Event.MarkRemoveEvent.visibility", "#[serde(flatten)]")
         .build_server(true)
+        .build_client(true)
         .compile(&["protos/dcs.proto"], &["protos"])?;
     Ok(())
 }

--- a/lua/grpc.lua
+++ b/lua/grpc.lua
@@ -7,6 +7,17 @@ package.loaded["dcs_grpc_server"] = nil
 grpc = require "dcs_grpc_server"
 grpc.start()
 GRPC.stopped = false
+GRPC.options = {
+  evalEnabled = false
+}
+
+--
+-- Methods to set options
+--
+
+GRPC.enableEval = function()
+  GRPC.options.evalEnabled = true
+end
 
 --
 -- Export methods
@@ -68,6 +79,16 @@ GRPC.errorUnimplemented = function(msg)
   return {
     error = {
       type = "UNIMPLEMENTED",
+      message = msg,
+    }
+  }
+end
+
+--- The caller does not have permission to execute the specified operation.
+GRPC.errorPermissionDenied = function(msg)
+  return {
+    error = {
+      type = "PERMISSION_DENIED",
       message = msg,
     }
   }

--- a/lua/methods/custom.lua
+++ b/lua/methods/custom.lua
@@ -11,6 +11,10 @@ GRPC.methods.joinMission = function(params)
 end
 
 GRPC.methods.eval = function(params)
+    if GRPC.options.evalEnabled ~= true then
+        return GRPC.errorPermissionDenied("eval operation is disabled")
+    end
+
     local fn, err = loadstring(params.lua)
     if not fn then
         return GRPC.error("Failed to load Lua code: "..err)

--- a/lua/methods/custom.lua
+++ b/lua/methods/custom.lua
@@ -1,5 +1,5 @@
 --
--- APIs for functions that are not built-in to the DCS Mission Scripting Environment 
+-- APIs for functions that are not built-in to the DCS Mission Scripting Environment
 --
 
 GRPC.methods.requestMissionAssignment = function(params)
@@ -8,4 +8,18 @@ end
 
 GRPC.methods.joinMission = function(params)
     return GRPC.errorUnimplemented("This method is not implemented")
+end
+
+GRPC.methods.eval = function(params)
+    local fn, err = loadstring(params.lua)
+    if not fn then
+        return GRPC.error("Failed to load Lua code: "..err)
+    end
+
+    local ok, result = pcall(fn)
+    if not ok then
+        return GRPC.error("Failed to execute Lua code: "..result)
+    end
+
+    return GRPC.success(result)
 end

--- a/protos/custom.proto
+++ b/protos/custom.proto
@@ -15,3 +15,11 @@ message MissionJoinRequest {
 }
 
 message MissionJoinResponse {}
+
+message EvalRequest {
+  string lua = 1;
+}
+
+message EvalResponse {
+  string json = 1;
+}

--- a/protos/dcs.proto
+++ b/protos/dcs.proto
@@ -37,6 +37,9 @@ service Custom {
 
 	// DCT Function
 	rpc JoinMission(MissionJoinRequest) returns (MissionJoinResponse) {}
+
+	// Evaluate some Lua inside of the mission and return the result as a JSON string.
+	rpc Eval(EvalRequest) returns (EvalResponse) {}
 }
 
 service Mission {

--- a/src/bin/repl.rs
+++ b/src/bin/repl.rs
@@ -1,0 +1,54 @@
+use std::io::{self, BufRead};
+
+use dcs_grpc_server::rpc::dcs::custom_client::CustomClient;
+use dcs_grpc_server::rpc::dcs::{EvalRequest, EvalResponse};
+use serde_json::Value;
+use tonic::{transport, Code, Request, Response, Status};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let endpoint =
+        transport::Endpoint::from_static("http://127.0.0.1:50051").keep_alive_while_idle(true);
+    let mut client = CustomClient::connect(endpoint).await?;
+
+    let stdin = io::stdin();
+    let mut lines = stdin.lock().lines();
+    loop {
+        if let Some(line) = lines.next() {
+            let req = Request::new(EvalRequest { lua: line? });
+            let result = client.eval(req).await;
+
+            let json: Value = match handle_respone(result) {
+                Ok(json) => json,
+                Err(Error::Grpc(err)) if err.code() == Code::Unavailable => {
+                    return Err(err.into());
+                }
+                Err(err) => {
+                    eprintln!("{}", err);
+                    continue;
+                }
+            };
+
+            if let Some(s) = json.as_str() {
+                println!("= {}", s);
+            } else {
+                let json = serde_json::to_string_pretty(&json)?;
+                println!("= {}", json);
+            }
+        }
+    }
+}
+
+fn handle_respone(res: Result<Response<EvalResponse>, Status>) -> Result<Value, Error> {
+    let json = res?.into_inner().json;
+    let json: Value = serde_json::from_str(&json)?;
+    Ok(json)
+}
+
+#[derive(Debug, thiserror::Error)]
+enum Error {
+    #[error(transparent)]
+    Grpc(#[from] Status),
+    #[error("failed to decode JSON result")]
+    Json(#[from] serde_json::Error),
+}

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -336,6 +336,15 @@ impl Custom for RPC {
         self.notification("joinMission", request).await?;
         Ok(Response::new(MissionJoinResponse {}))
     }
+
+    async fn eval(&self, request: Request<EvalRequest>) -> Result<Response<EvalResponse>, Status> {
+        let json: serde_json::Value = self.request("eval", request).await?;
+        dbg!(&json);
+        let json = serde_json::to_string(&json).map_err(|err| {
+            Status::internal(format!("failed to deserialize eval result: {}", err))
+        })?;
+        Ok(Response::new(EvalResponse { json }))
+    }
 }
 
 fn to_status(err: dcs_module_ipc::Error) -> Status {


### PR DESCRIPTION
A REPL into the DCS scripting environment is something I am using quite heavily during development, so I gave it a try to implement it for the gRPC server.

![image](https://user-images.githubusercontent.com/409021/131030191-7336299e-fa78-4d1c-ba53-6114a0e92309.png)

Usage:

```bash
cargo build --bin repl
# start DCS mission
cargo run --bin repl
```

Wdyt, should we keep it?