### PR TITLE
log everything into gRPC.log

### DIFF
--- a/lua/grpc.lua
+++ b/lua/grpc.lua
@@ -44,6 +44,20 @@ GRPC.error = function(msg)
   }
 end
 
+--
+-- Logging methods
+--
+
+GRPC.logError = function(err)
+  grpc.log_error(err)
+  env.error("[GRPC] "..err)
+end
+
+GRPC.logWarning = function(err)
+  grpc.log_warning(err)
+  env.warning("[GRPC] "..err)
+end
+
 --- The client specified an invalid argument
 GRPC.errorInvalidArgument = function(msg)
   return {
@@ -119,7 +133,7 @@ local function handleRequest(method, params)
     if ok then
       return result
     else
-      env.error("[GRPC] error executing "..method..": "..tostring(result))
+      GRPC.logError("error executing "..method..": "..tostring(result))
       return {
         error = tostring(result)
       }
@@ -148,7 +162,7 @@ timer.scheduleFunction(function()
   if not GRPC.stopped then
     local ok, err = pcall(next)
     if not ok then
-      env.error("[GRPC] Error retrieving next command: "..tostring(err))
+      GRPC.logError("Error retrieving next command: "..tostring(err))
     end
 
     return timer.getTime() + .02 -- return time of next call
@@ -177,7 +191,7 @@ function eventHandler:onEvent(event)
         end
       end
     else
-      env.error("[GRPC] Error in event handler: "..tostring(result))
+      GRPC.logError("Error in event handler: "..tostring(err))
     end
   end
 end

--- a/lua/methods/mission.lua
+++ b/lua/methods/mission.lua
@@ -19,7 +19,7 @@ local function exporter(object)
   elseif category == Object.Category.Cargo then
     return GRPC.exporters.cargo(object)
   else
-    env.info("[GRPC] Could not determine object category of object with ID: " .. object:getID() .. ", Category: " .. category)
+    GRPC.logWarning("Could not determine object category of object with ID: " .. object:getID() .. ", Category: " .. category)
     return nil
   end
 end
@@ -45,7 +45,7 @@ local function typed_exporter(object)
   elseif category == Object.Category.Cargo then
     grpcTable["cargo"] = exporter(object)
   else
-    env.info("[GRPC] Could not determine object category of object with ID: " .. object:getID() .. ", Category: " .. category)
+    GRPC.logWarning("Could not determine object category of object with ID: " .. object:getID() .. ", Category: " .. category)
     grpcTable["unknown"] = GRPC.exporters.unknown(object)
   end
 
@@ -400,7 +400,7 @@ GRPC.onDcsEvent = function(event)
   -- S_EVENT_MAX: assumingly an end marker for the events enum and thus not a real event
 
   else
-    env.info("[GRPC] Skipping unimplemented event id "..tostring(event.id))
+    GRPC.logWarning("Skipping unimplemented event id "..tostring(event.id))
     return nil
   end
 end

--- a/lua/methods/unit.lua
+++ b/lua/methods/unit.lua
@@ -37,7 +37,7 @@ GRPC.methods.getRadar = function(params)
   elseif(category == Object.Category.Cargo) then
     grpcTable["cargo"] = GRPC.exporters.cargo(object)
   else
-    env.info("[GRPC] Could not determine object category of object with ID: " .. object:getID() .. ", Category: " .. category)
+    GRPC.logWarning("Could not determine object category of object with ID: " .. object:getID() .. ", Category: " .. category)
     grpcTable["object"] = GRPC.exporters.object(object)
   end
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,6 +199,16 @@ fn event(lua: &Lua, event: Value) -> LuaResult<()> {
     Ok(())
 }
 
+fn log_error(_: &Lua, err: String) -> LuaResult<()> {
+    log::error!("{}", err);
+    Ok(())
+}
+
+fn log_warning(_: &Lua, err: String) -> LuaResult<()> {
+    log::warn!("{}", err);
+    Ok(())
+}
+
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Failed to deserialize params: {0}")]
@@ -221,6 +231,8 @@ pub fn dcs_grpc_server(lua: &Lua) -> LuaResult<LuaTable> {
     exports.set("stop", lua.create_function(stop)?)?;
     exports.set("next", lua.create_function(next)?)?;
     exports.set("event", lua.create_function(event)?)?;
+    exports.set("log_error", lua.create_function(log_error)?)?;
+    exports.set("log_warning", lua.create_function(log_warning)?)?;
     Ok(exports)
 }
 


### PR DESCRIPTION
I was a bit annoyed that I always have to watch both `dcs.log` and `gRPC.log` to find all error/warning logs. This PR makes sure that everything is logged into `gRPC.log`.

Wdyt?