### PR TITLE
extend gRPC server's access to DCS' hook env

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,11 +14,22 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      LUA_LIB_NAME: lua
+      LUA_LIB: ${{ github.workspace }}/lua/lua5.1/
+      LUA_INC: ${{ github.workspace }}/lua/lua5.1/include
+
     steps:
     - uses: actions/checkout@v2
+
     - name: Build
-      run: make build
+      run: cargo build
+
+    - name: Build with hot-reload feature
+      run: cargo build --features hot-reload
+
     - name: Run tests
-      run: make test
+      run: cargo test
+
     - name: Check formatting
       run: cargo fmt -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 dcs-module-ipc = "0.5"
 futures-util = "0.3"
+libloading = { version = "0.7", optional = true }
 log4rs = "1.0"
 log = "0.4"
 mlua = { version = "0.6", default-features = false, features = ["lua51", "module", "serialize"] }
@@ -30,3 +31,7 @@ serde_json = "1.0"
 
 [build-dependencies]
 tonic-build = "0.4"
+
+[features]
+default = []
+hot-reload = ["libloading"]

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,14 @@ build: export LUA_LIB_NAME=lua
 build: export LUA_LIB=$(CURDIR)/lua/lua5.1/
 build: export LUA_INC=$(CURDIR)/lua/lua5.1/include
 build:
-	cargo build
+	cargo build --features hot-reload
+	powershell copy target/debug/dcs_grpc_server.dll target/debug/dcs_grpc_server_hot_reload.dll
 
 watch: export LUA_LIB_NAME=lua
 watch: export LUA_LIB=$(CURDIR)/lua/lua5.1/
 watch: export LUA_INC=$(CURDIR)/lua/lua5.1/include
 watch:
-	cargo watch
+	cargo watch -x "check --features hot-reload"
 
 test: export LUA_LIB_NAME=lua
 test: export LUA_LIB=$(CURDIR)/lua/lua5.1/

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ New-Item -ItemType SymbolicLink -Path "M:\Saved Games\DCS.openbeta\Scripts\DCS-g
 New-Item -ItemType SymbolicLink -Path "M:\Saved Games\DCS.openbeta\Scripts\Hooks\DCS-gRPC.lua" -Value "M:\Development\DCS-gRPC\rust-server\lua\grpc-hook.lua"
 New-Item -Path "M:\Saved Games\DCS.openbeta\Mods\Tech\DCS-gRPC" -ItemType "directory"
 New-Item -ItemType SymbolicLink -Path "M:\Saved Games\DCS.openbeta\Mods\Tech\DCS-gRPC\dcs_grpc_server.dll" -Value "M:\Development\DCS-gRPC\rust-server\target\debug\dcs_grpc_server.dll"
+New-Item -ItemType SymbolicLink -Path "M:\Saved Games\DCS.openbeta\Mods\Tech\DCS-gRPC\dcs_grpc_server_hot_reload.dll" -Value "M:\Development\DCS-gRPC\rust-server\target\debug\dcs_grpc_server_hot_reload.dll"
 ```
 
 ### Mission Setup
@@ -128,10 +129,6 @@ or watch the mission event stream via:
 ```bash
 grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs.proto -d '{}' 127.0.0.1:50051 dcs.Mission/StreamEvents
 ```
-
-### Reload changes
-
-To reload changes during development it is enough to restart a mission to reload changes related to the mission environment, but it is required to restart DCS to reload changes made to the hook environment.
 
 ### Troublshooting
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,24 @@ end
 
 ### Mission Editing
 
-Create a trigger of type `MISSION START` and add a `DO SCRIPT FILE` action loading `Scripts\DCS-gRPC\grpc-mission.lua`.
+Add the following code to your mission. This will start the DCS-gRPC server. You can add this code
+
+- to a `DO SCRIPT FILE` trigger action loading `Scripts\DCS-gRPC\grpc-mission.lua`, or
+- to a `DO SCRIPT` trigger action (or include it in your own scripts if you already have some) with the following script:
+
+    ```lua
+    package.cpath = package.cpath..lfs.writedir()..[[Mods\tech\DCS-gRPC\?.dll;]]
+    GRPC = { basePath = lfs.writedir()..[[Scripts\DCS-gRPC\]] }
+
+    local luaPath = GRPC.basePath .. [[grpc.lua]]
+    local f = assert( loadfile(luaPath) )
+
+    if f == nil then
+      error ("[GRPC]: Could not load " .. luaPath )
+    else
+      f()
+    end
+    ```
 
 ### Confirmation
 
@@ -67,9 +84,7 @@ $env:LUA_INC=(Get-Item -Path ".\").FullName+"/lua/lua5.1/include"
 cargo build
 ```
 
-### Link files
-
-To always have the latest development changes
+### MissionScripting Sanitisation Removal
 
 DCS-gRPC requires the removal of sanitisation features in DCS scripting.
 
@@ -89,8 +104,19 @@ do
 end
 ```
 
-Instead of copying the files to their respective destination as done in the normal [Installation](#installation), it is recommended to create symbolic links for development instead.
+### Mission Setup
 
+Add the following script to your mission (adjust the paths to match your repo location):
+
+```lua
+package.cpath = package.cpath..[[C:\Development\DCS-gRPC\rust-server\target\debug\?.dll;]]
+GRPC = { basePath = [[C:\Development\DCS-gRPC\rust-server\lua\]] }
+dofile(GRPC.basePath
+```
+
+#### Link files
+
+Instead of pointing your mission to your dev environment, you can also create symbolic links instead.
 This can be done using powershell. Before running the commands, update the paths accordingly.
 
 Build to make sure all files exist:
@@ -102,16 +128,12 @@ make build
 Create directories and links:
 
 ```ps1
-New-Item -ItemType SymbolicLink -Path "M:\Saved Games\DCS.openbeta\Scripts\DCS-gRPC" -Value "M:\Development\DCS-gRPC\rust-server\lua"
-New-Item -ItemType SymbolicLink -Path "M:\Saved Games\DCS.openbeta\Scripts\Hooks\DCS-gRPC.lua" -Value "M:\Development\DCS-gRPC\rust-server\lua\grpc-hook.lua"
-New-Item -Path "M:\Saved Games\DCS.openbeta\Mods\Tech\DCS-gRPC" -ItemType "directory"
-New-Item -ItemType SymbolicLink -Path "M:\Saved Games\DCS.openbeta\Mods\Tech\DCS-gRPC\dcs_grpc_server.dll" -Value "M:\Development\DCS-gRPC\rust-server\target\debug\dcs_grpc_server.dll"
-New-Item -ItemType SymbolicLink -Path "M:\Saved Games\DCS.openbeta\Mods\Tech\DCS-gRPC\dcs_grpc_server_hot_reload.dll" -Value "M:\Development\DCS-gRPC\rust-server\target\debug\dcs_grpc_server_hot_reload.dll"
+New-Item -ItemType SymbolicLink -Path "C:\Users\YOUR_USER\Saved Games\DCS.openbeta\Scripts\DCS-gRPC" -Value "C:\Development\DCS-gRPC\rust-server\rust-server\lua"
+New-Item -ItemType SymbolicLink -Path "C:\Users\YOUR_USER\Saved Games\DCS.openbeta\Scripts\Hooks\DCS-gRPC.lua" -Value "C:\Development\DCS-gRPC\rust-server\rust-server\lua\grpc-hook.lua"
+New-Item -Path "C:\Users\YOUR_USER\Saved Games\DCS.openbeta\Mods\Tech\DCS-gRPC" -ItemType "directory"
+New-Item -ItemType SymbolicLink -Path "C:\Users\YOUR_USER\Saved Games\DCS.openbeta\Mods\Tech\DCS-gRPC\dcs_grpc_server.dll" -Value "C:\Development\DCS-gRPC\rust-server\rust-server\target\debug\dcs_grpc_server.dll"
+New-Item -ItemType SymbolicLink -Path "C:\Users\YOUR_USER\Saved Games\DCS.openbeta\Mods\Tech\DCS-gRPC\dcs_grpc_server_hot_reload.dll" -Value "C:\Development\DCS-gRPC\rust-server\rust-server\target\debug\dcs_grpc_server_hot_reload.dll"
 ```
-
-### Mission Setup
-
-Add `Scripts\DCS-gRPC\grpc-mission.lua` to your mission.
 
 ### Debugging
 

--- a/lua/grpc-hook.lua
+++ b/lua/grpc-hook.lua
@@ -1,0 +1,22 @@
+local function init()
+  log.write("[GRPC]", log.ERROR, "Initializing hook ...")
+
+  package.cpath = package.cpath..lfs.writedir()..[[Mods\tech\DCS-gRPC\?.dll;]]
+  _G.GRPC = { basePath = lfs.writedir()..[[Scripts\DCS-gRPC\]] }
+
+  local luaPath = _G.GRPC.basePath..[[grpc.lua]]
+  local f = assert(loadfile(luaPath))
+
+  if f == nil then
+    error("[GRPC]: Could not load "..luaPath)
+  else
+    f()
+  end
+
+  log.write("[GRPC]", log.ERROR, "Hook initialized ...")
+end
+
+local ok, err = pcall(init)
+if not ok then
+  log.write("[GRPC]", log.ERROR, "Failed to init: "..tostring(err))
+end

--- a/lua/grpc-hook.lua
+++ b/lua/grpc-hook.lua
@@ -1,22 +1,44 @@
+package.cpath = package.cpath..lfs.writedir()..[[Mods\tech\DCS-gRPC\?.dll;]]
+
 local function init()
-  log.write("[GRPC]", log.ERROR, "Initializing hook ...")
+  log.write("[GRPC-Hook]", log.INFO, "Initializing ...")
 
-  package.cpath = package.cpath..lfs.writedir()..[[Mods\tech\DCS-gRPC\?.dll;]]
-  _G.GRPC = { basePath = lfs.writedir()..[[Scripts\DCS-gRPC\]] }
+  local handler = {}
 
-  local luaPath = _G.GRPC.basePath..[[grpc.lua]]
-  local f = assert(loadfile(luaPath))
+  function handler.onMissionLoadEnd()
+    log.write("[GRPC-Hook]", log.INFO, "mission loaded, setting up gRPC listener ...")
 
-  if f == nil then
-    error("[GRPC]: Could not load "..luaPath)
-  else
-    f()
+    _G.GRPC = { basePath = lfs.writedir()..[[Scripts\DCS-gRPC\]] }
+
+    local luaPath = _G.GRPC.basePath..[[grpc.lua]]
+    local f = assert(loadfile(luaPath))
+
+    if f == nil then
+      error("[GRPC-Hook]: Could not load "..luaPath)
+    else
+      f()
+    end
   end
 
-  log.write("[GRPC]", log.ERROR, "Hook initialized ...")
+  function handler.onSimulationFrame()
+    if GRPC.onSimulationFrame then
+      GRPC.onSimulationFrame()
+    end
+  end
+
+  function handler.onSimulationStop()
+    log.write("[GRPC-Hook]", log.INFO, "simulation stopped, shutting down gRPC listener ...")
+
+    _G.GRPC.stop()
+    _G.GRPC = nil
+  end
+
+  DCS.setUserCallbacks(handler)
+
+  log.write("[GRPC-Hook]", log.INFO, "Initialized ...")
 end
 
 local ok, err = pcall(init)
 if not ok then
-  log.write("[GRPC]", log.ERROR, "Failed to init: "..tostring(err))
+  log.write("[GRPC-Hook]", log.ERROR, "Failed to Initialize: "..tostring(err))
 end

--- a/lua/grpc-mission.lua
+++ b/lua/grpc-mission.lua
@@ -1,0 +1,11 @@
+package.cpath = package.cpath..lfs.writedir()..[[Mods\tech\DCS-gRPC\?.dll;]]
+GRPC = { basePath = lfs.writedir()..[[Scripts\DCS-gRPC\]] }
+
+local luaPath = GRPC.basePath..[[grpc.lua]]
+local f = assert(loadfile(luaPath))
+
+if f == nil then
+  error("[GRPC]: Could not load "..luaPath)
+else
+  f()
+end

--- a/lua/methods/hook.lua
+++ b/lua/methods/hook.lua
@@ -1,0 +1,10 @@
+--
+-- Hook actions
+-- Docs: /DCS World/API/DCS_ControlAPI.html
+--
+
+local GRPC = GRPC
+
+GRPC.methods.getMissionName = function()
+  return GRPC.success({name = DCS.getMissionName()})
+end

--- a/protos/dcs.proto
+++ b/protos/dcs.proto
@@ -6,6 +6,7 @@ import "common.proto";
 import "controllers.proto";
 import "custom.proto";
 import "group.proto";
+import "hook.proto";
 import "mission.proto";
 import "timer.proto";
 import "trigger.proto";
@@ -116,6 +117,10 @@ service Groups {
 	rpc GetUnits(dcs.group.GetUnitsRequest) returns (dcs.group.GetUnitsResponse) {}
 }
 
+service Hook {
+	rpc GetMissionName(dcs.hook.GetMissionNameRequest) returns (dcs.hook.GetMissionNameResponse) {}
+}
+
 service Units {
 	// https://wiki.hoggitworld.com/view/DCS_func_getRadar
 	rpc GetRadar(GetRadarRequest) returns (GetRadarResponse) {}
@@ -136,3 +141,4 @@ service World {
 	// https://wiki.hoggitworld.com/view/DCS_func_getMarkPanels
 	rpc GetMarkPanels(GetMarkPanelsRequest) returns (GetMarkPanelsResponse) {}
 }
+

--- a/protos/hook.proto
+++ b/protos/hook.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+import "common.proto";
+
+package dcs.hook;
+
+message GetMissionNameRequest {}
+
+message GetMissionNameResponse {
+  string name = 1;
+}

--- a/src/hot_reload.rs
+++ b/src/hot_reload.rs
@@ -1,0 +1,92 @@
+///! This module is a wrapper around all exposed Lua methods which are forwarded to a dynamically
+///! loaded dcs_grpc_server.dll. Upon calling the `stop()` method, the library is unloaded, and re-
+///! loaded during the next `start()` call.
+use std::sync::{Arc, RwLock};
+
+use libloading::{Library, Symbol};
+use mlua::prelude::*;
+use mlua::{Function, Value};
+use once_cell::sync::Lazy;
+
+static LIBRARY: Lazy<RwLock<Option<Library>>> = Lazy::new(|| RwLock::new(None));
+
+pub fn start(lua: &Lua, is_mission_env: bool) -> LuaResult<()> {
+    let write_dir = super::init(lua)?;
+    let lib_path = write_dir.clone() + "Mods/Tech/DCS-gRPC/dcs_grpc_server.dll";
+
+    let new_lib = unsafe { Library::new(lib_path) }.map_err(|err| {
+        log::error!("Load: {}", err);
+        mlua::Error::ExternalError(Arc::new(err))
+    })?;
+    let mut lib = LIBRARY.write().unwrap();
+    let lib = lib.get_or_insert(new_lib);
+
+    let f: Symbol<fn(lua: &Lua, is_mission_env: bool) -> LuaResult<()>> = unsafe {
+        lib.get(b"start")
+            .map_err(|err| mlua::Error::ExternalError(Arc::new(err)))?
+    };
+    let result = f(lua, is_mission_env);
+
+    result
+}
+
+pub fn stop(lua: &Lua, arg: ()) -> LuaResult<()> {
+    if let Some(lib) = LIBRARY.write().unwrap().take() {
+        log::debug!("CLOSING LIBRARY");
+        let f: Symbol<fn(lua: &Lua, arg: ()) -> LuaResult<()>> = unsafe {
+            lib.get(b"stop")
+                .map_err(|err| mlua::Error::ExternalError(Arc::new(err)))?
+        };
+        f(lua, arg)
+    } else {
+        Ok(())
+    }
+}
+
+pub fn next(lua: &Lua, arg: (i32, Function)) -> LuaResult<bool> {
+    if let Some(ref lib) = *LIBRARY.read().unwrap() {
+        let f: Symbol<fn(lua: &Lua, arg: (i32, Function)) -> LuaResult<bool>> = unsafe {
+            lib.get(b"next")
+                .map_err(|err| mlua::Error::ExternalError(Arc::new(err)))?
+        };
+        f(lua, arg)
+    } else {
+        Ok(false)
+    }
+}
+
+pub fn event(lua: &Lua, event: Value) -> LuaResult<()> {
+    if let Some(ref lib) = *LIBRARY.read().unwrap() {
+        let f: Symbol<fn(lua: &Lua, event: Value) -> LuaResult<()>> = unsafe {
+            lib.get(b"event")
+                .map_err(|err| mlua::Error::ExternalError(Arc::new(err)))?
+        };
+        f(lua, event)
+    } else {
+        Ok(())
+    }
+}
+
+pub fn log_error(lua: &Lua, err: String) -> LuaResult<()> {
+    if let Some(ref lib) = *LIBRARY.read().unwrap() {
+        let f: Symbol<fn(lua: &Lua, err: String) -> LuaResult<()>> = unsafe {
+            lib.get(b"log_error")
+                .map_err(|err| mlua::Error::ExternalError(Arc::new(err)))?
+        };
+        f(lua, err)
+    } else {
+        Ok(())
+    }
+}
+
+pub fn log_warning(lua: &Lua, err: String) -> LuaResult<()> {
+    if let Some(ref lib) = *LIBRARY.read().unwrap() {
+        let f: Symbol<fn(lua: &Lua, err: String) -> LuaResult<()>> = unsafe {
+            lib.get(b"log_error")
+                .map_err(|err| mlua::Error::ExternalError(Arc::new(err)))?
+        };
+        f(lua, err)
+    } else {
+        Ok(())
+    }
+}

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -11,7 +11,7 @@ use crate::rpc::dcs::{
     Coalition, GetGroupsRequest, GetUnitPlayerNameRequest, GetUnitPositionRequest, Position,
     StreamUnitsRequest, Unit,
 };
-use crate::rpc::RPC;
+use crate::rpc::MissionRpc;
 use futures_util::stream::StreamExt;
 use tokio::sync::mpsc::error::SendError;
 use tokio::sync::mpsc::Sender;
@@ -21,7 +21,7 @@ use tonic::{Code, Request, Status};
 /// Stream unit updates.
 pub async fn stream_units(
     opts: StreamUnitsRequest,
-    rpc: RPC,
+    rpc: MissionRpc,
     tx: Sender<Result<Update, Status>>,
 ) -> Result<(), Error> {
     // initialize the state for the current units stream instance
@@ -119,7 +119,7 @@ struct State {
 
 /// Various structs and options used to handle unit updates.
 struct Context {
-    rpc: RPC,
+    rpc: MissionRpc,
     tx: Sender<Result<Update, Status>>,
     poll_rate: Duration,
     max_backoff: Duration,


### PR DESCRIPTION
I am have to admit, I am still surprised that this ended up working, which makes be a bit suspicious. I am thus considering this a draft for now, and am planning on doing some more stability tests and some reading on certain things I don't quite understand why they work.

This PR:
- adds a DCS hook (lua file into `Scripts/Hooks/`) which allows handling RPC calls inside of the hooks environment (does not need a second server)
- implements hot-reloading of the DLL to still be able to recompile the DLL between mission restarts (I'd hate having to restart DCS for each change)
- adds `dcs.Hook/GetMissionName` as a first example for a method calling into the hook

More details will follow as inline comments.

Example to test that both envs still work:

```
.\grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs.proto -d '{\"text\": \"Works!\", \"display_time\": 10, \"clear_view\": false}' 127.0.0.1:50051 dcs.Triggers/OutText

.\grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs.proto -d '{}' 127.0.0.1:50051 dcs.Hook/GetMissionName
```