### PR TITLE
Add Controllers service

### DIFF
--- a/lua/grpc.lua
+++ b/lua/grpc.lua
@@ -115,6 +115,7 @@ end
 GRPC.methods = {}
 dofile(GRPC.basePath .. [[methods\atmosphere.lua]])
 dofile(GRPC.basePath .. [[methods\coalitions.lua]])
+dofile(GRPC.basePath .. [[methods\controllers.lua]])
 dofile(GRPC.basePath .. [[methods\custom.lua]])
 dofile(GRPC.basePath .. [[methods\group.lua]])
 dofile(GRPC.basePath .. [[methods\mission.lua]])

--- a/lua/methods/controllers.lua
+++ b/lua/methods/controllers.lua
@@ -1,0 +1,34 @@
+local GRPC = GRPC
+local unit = unit
+local group = group
+local AI = AI
+
+local group_option_category = {}
+group_option_category[1] = "Air"
+group_option_category[2] = "Ground"
+group_option_category[3] = "Naval"
+
+GRPC.methods.setAlarmState = function(params)
+  local obj
+
+  if params.name.groupName then
+    obj = Group.getByName(params.name.groupName)
+  elseif  params.name.unitName then
+    obj = Unit.getByName(params.name.unitName)
+  else
+    return GRPC.errorInvalidArgument("No Group or Unit name provided")
+  end
+
+  if obj == nil then
+    return GRPC.errorNotFound("Could not find group or unit with provided name")
+  end
+
+  local controller = obj:getController()
+  local category_id = obj:getCategory()
+
+  local state_id = AI['Option'][group_option_category[category_id]]['id']['ALARM_STATE']
+
+  controller:setOption(state_id, params.alarmState)
+
+  return GRPC.success(nil)
+end

--- a/protos/controllers.proto
+++ b/protos/controllers.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package dcs;
+
+message SetAlarmStateRequest {
+	enum AlarmState {
+		AUTO = 0;
+		GREEN = 1;
+		RED = 2;
+	}
+
+	oneof name {
+	  string group_name = 1;
+	  string unit_name = 2;
+	}
+	AlarmState alarm_state = 3;
+}

--- a/protos/dcs.proto
+++ b/protos/dcs.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 import "atmosphere.proto";
 import "coalitions.proto";
 import "common.proto";
+import "controllers.proto";
 import "custom.proto";
 import "group.proto";
 import "mission.proto";
@@ -30,6 +31,11 @@ service Coalitions {
 
 	// https://wiki.hoggitworld.com/view/DCS_func_getGroups
 	rpc GetGroups(GetGroupsRequest) returns (GetGroupsResponse) {}
+}
+
+service Controllers {
+    // https://wiki.hoggitworld.com/view/DCS_option_alarmState
+	rpc SetAlarmState(SetAlarmStateRequest) returns (EmptyResponse) {}
 }
 
 service Custom {

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -3,6 +3,7 @@ use std::pin::Pin;
 use crate::shutdown::{AbortableStream, ShutdownHandle};
 use dcs::atmosphere_server::Atmosphere;
 use dcs::coalitions_server::Coalitions;
+use dcs::controllers_server::Controllers;
 use dcs::custom_server::Custom;
 use dcs::groups_server::Groups;
 use dcs::mission_server::Mission;
@@ -305,6 +306,17 @@ impl Coalitions for RPC {
     ) -> Result<Response<GetGroupsResponse>, Status> {
         let res: GetGroupsResponse = self.request("getGroups", request).await?;
         Ok(Response::new(res))
+    }
+}
+
+#[tonic::async_trait]
+impl Controllers for RPC {
+    async fn set_alarm_state(
+        &self,
+        request: Request<SetAlarmStateRequest>,
+    ) -> Result<Response<EmptyResponse>, Status> {
+        self.notification("setAlarmState", request).await?;
+        Ok(Response::new(EmptyResponse {}))
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,6 +5,7 @@ use crate::rpc::RPC;
 use crate::shutdown::ShutdownHandle;
 use dcs::atmosphere_server::AtmosphereServer;
 use dcs::coalitions_server::CoalitionsServer;
+use dcs::controllers_server::ControllersServer;
 use dcs::custom_server::CustomServer;
 use dcs::mission_server::MissionServer;
 use dcs::timer_server::TimerServer;
@@ -47,6 +48,7 @@ async fn try_run(
     Server::builder()
         .add_service(AtmosphereServer::new(rpc.clone()))
         .add_service(CoalitionsServer::new(rpc.clone()))
+        .add_service(ControllersServer::new(rpc.clone()))
         .add_service(CustomServer::new(rpc.clone()))
         .add_service(MissionServer::new(rpc.clone()))
         .add_service(TimerServer::new(rpc.clone()))


### PR DESCRIPTION
Add a Controllers service that allows for accessing the AI controller of a unit or group.

## Review Question 1

I have created a Controllers service where every API will have to take either a `group_name` or a `unit_name`. An alternative to this is that we have the APIs (e.g.) `SetAlarmState` API duplicated in the protos for both `Unit` and `Group`  and then have them both point to the shared lua implementation. Which do you prefer?

## Review Question 2

I am unable to actually run this as I am getting an exception building. could you have a look and see if I have missed anything obvious? I have stared at the code for a while and cannot see it:

```
Caused by:
  process didn't exit successfully: `C:\Users\jeff\source\repos\rust-server\target\debug\build\dcs-grpc-server-7638a43898b30456\build-script-build` (exit code: 101)
  --- stderr
  thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', C:\Users\jeff\.cargo\registry\src\github.com-1ecc6299db9ec823\prost-build-0.7.0\src\code_generator.rs:259:47
  stack backtrace:
     0: std::panicking::begin_panic_handler
               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633\/library\std\src\panicking.rs:515
     1: core::panicking::panic_fmt
               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633\/library\core\src\panicking.rs:92
     2: core::panicking::panic
               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633\/library\core\src\panicking.rs:50
     3: enum$<core::option::Option<alloc::vec::Vec<tuple<prost_types::FieldDescriptorProto, usize>, alloc::alloc::Global>>, 1, 18446744073709551615, Some>::unwrap<alloc::vec::Vec<tuple<prost_types::FieldDescriptorProto, usize>, alloc::alloc::Global>>
               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633\library\core\src\option.rs:388
     4: prost_build::code_generator::CodeGenerator::append_message
               at C:\Users\jeff\.cargo\registry\src\github.com-1ecc6299db9ec823\prost-build-0.7.0\src\code_generator.rs:259
     5: prost_build::code_generator::CodeGenerator::generate
               at C:\Users\jeff\.cargo\registry\src\github.com-1ecc6299db9ec823\prost-build-0.7.0\src\code_generator.rs:102
     6: prost_build::Config::generate
               at C:\Users\jeff\.cargo\registry\src\github.com-1ecc6299db9ec823\prost-build-0.7.0\src\lib.rs:766
     7: prost_build::Config::compile_protos<str>
               at C:\Users\jeff\.cargo\registry\src\github.com-1ecc6299db9ec823\prost-build-0.7.0\src\lib.rs:725
     8: tonic_build::prost::Builder::compile_with_config<str>
               at C:\Users\jeff\.cargo\registry\src\github.com-1ecc6299db9ec823\tonic-build-0.4.2\src\prost.rs:369
     9: tonic_build::prost::Builder::compile<str>
               at C:\Users\jeff\.cargo\registry\src\github.com-1ecc6299db9ec823\tonic-build-0.4.2\src\prost.rs:323
    10: build_script_build::main
               at .\build.rs:2
    11: core::ops::function::FnOnce::call_once<fn() -> enum$<core::result::Result<tuple<>, alloc::boxed::Box<Error, alloc::alloc::Global>>, 1, 18446744073709551615, Err>,tuple<>>
               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633\library\core\src\ops\function.rs:227
  note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
