### PR TITLE
implement chat filter POC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,15 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.0", features = ["rt-multi-thread", "time", "sync"] }
-tokio-stream = "0.1"
+tokio-stream = { version = "0.1", features = ["sync"] }
 tonic = "0.4"
+uuid = { version = "0.8", features = ["v4"] }
 
 [dev-dependencies]
+backoff = { version = "0.3", features = ["tokio"] }
+pretty_env_logger = "0.4"
 serde_json = "1.0"
+tokio =  { version = "1.2", features = ["macros", "signal"] }
 
 [build-dependencies]
 tonic-build = "0.4"

--- a/examples/chat_filter.rs
+++ b/examples/chat_filter.rs
@@ -1,0 +1,71 @@
+use std::time::Duration;
+
+use backoff::ExponentialBackoff;
+use dcs_grpc_server::rpc::dcs::hook::{FilterChatMessageRequest, StreamChatRequest};
+use dcs_grpc_server::rpc::dcs::hook_client::HookClient;
+use futures_util::future::{select, FutureExt};
+use futures_util::stream::StreamExt;
+use log::LevelFilter;
+use tonic::{transport, Request, Status};
+
+async fn run() -> Result<(), Error> {
+    let addr = "http://127.0.0.1:50051";
+    log::debug!("Connecting to gRPC server at {}", addr);
+
+    let endpoint = transport::Endpoint::from_static(addr).keep_alive_while_idle(true);
+    let mut client = HookClient::connect(endpoint).await?;
+    let mut chat_messages = client
+        .stream_chat(Request::new(StreamChatRequest {}))
+        .await?
+        .into_inner();
+
+    while let Some(msg) = chat_messages.next().await {
+        let msg = msg?;
+        client
+            .filter_chat_message(Request::new(FilterChatMessageRequest {
+                uuid: msg.uuid,
+                message: msg.message.to_uppercase(),
+            }))
+            .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() {
+    pretty_env_logger::formatted_builder()
+        .filter_module("chat_filter", LevelFilter::Debug)
+        .init();
+
+    let backoff = ExponentialBackoff {
+        // never wait longer than 30s for a retry
+        max_interval: Duration::from_secs(30),
+        // never stop trying
+        max_elapsed_time: None,
+        ..Default::default()
+    };
+
+    select(
+        Box::pin(backoff::future::retry_notify(
+            backoff,
+            || async { run().await.map_err(backoff::Error::Transient) },
+            |err, backoff: Duration| {
+                log::error!("Error: {}", err);
+                log::info!("Retrying after error in {:.2}s", backoff.as_secs_f64());
+            },
+        )),
+        Box::pin(tokio::signal::ctrl_c().map(|_| ())),
+    )
+    .await;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    Grpc(#[from] Status),
+    #[error(transparent)]
+    Transport(#[from] tonic::transport::Error),
+    #[error("event stream ended")]
+    End,
+}

--- a/lua/grpc-hook.lua
+++ b/lua/grpc-hook.lua
@@ -33,6 +33,10 @@ local function init()
     _G.GRPC = nil
   end
 
+  function handler.onPlayerTrySendChat(playerID, msg, all)
+    return _G.GRPC.onChatMessage(playerID, msg, all)
+  end
+
   DCS.setUserCallbacks(handler)
 
   log.write("[GRPC-Hook]", log.INFO, "Initialized ...")

--- a/lua/grpc.lua
+++ b/lua/grpc.lua
@@ -59,6 +59,10 @@ GRPC.error = function(msg)
   }
 end
 
+GRPC.onChatMessage = function(playerID, msg, all)
+  return grpc.on_chat_message(playerID, msg, all)
+end
+
 --
 -- Logging methods
 --

--- a/protos/dcs.proto
+++ b/protos/dcs.proto
@@ -119,6 +119,16 @@ service Groups {
 
 service Hook {
 	rpc GetMissionName(dcs.hook.GetMissionNameRequest) returns (dcs.hook.GetMissionNameResponse) {}
+
+	// Stream all chat messages. Once a chat message stream is active, the gRPC server expects a
+	// `FilterChatMessageRequest` for each message letting the server know whether the chat message
+	// should be filtered or not. This request must be send ASAP, as the server is blocked until the
+	// request is received. If the server does not receive a `FilterChatMessageRequest` within
+	// 16 milliseconds, the chat message will thus be dropped to prevent the server from getting
+	// blocked too long.
+	rpc StreamChat(dcs.hook.StreamChatRequest) returns (stream dcs.hook.ChatMessage) {}
+
+	rpc FilterChatMessage(dcs.hook.FilterChatMessageRequest) returns (dcs.hook.FilterChatMessageResponse) {}
 }
 
 service Units {

--- a/protos/hook.proto
+++ b/protos/hook.proto
@@ -9,3 +9,30 @@ message GetMissionNameRequest {}
 message GetMissionNameResponse {
   string name = 1;
 }
+
+message StreamChatRequest {}
+
+message ChatMessage {
+  // The UUID of the message used to let the gRPC know whether the message should be filtered or
+  // not.
+  string uuid = 1;
+
+  // The ID of the player sending the chat messaage.
+  uint32 player_id = 2;
+
+  // The chat message.
+  string message = 3;
+
+  // Whether the message was send to all or only to allies.
+  bool all = 4;
+}
+
+message FilterChatMessageRequest {
+  // The UUID of the message.
+  string uuid = 1;
+
+  // The filtered content of the message. The message will be dropped if the string is empty.
+  string message = 2;
+}
+
+message FilterChatMessageResponse {}

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1,0 +1,79 @@
+use std::collections::HashMap;
+use std::mem;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::rpc::dcs::hook::ChatMessage;
+use tokio::sync::{broadcast, oneshot, Mutex};
+use tokio::time::timeout;
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct Chat {
+    stream: broadcast::Sender<ChatMessage>,
+    pending: Arc<Mutex<HashMap<Uuid, oneshot::Sender<String>>>>,
+}
+
+impl Chat {
+    pub fn new() -> Self {
+        let (tx, _) = broadcast::channel(128);
+        Self {
+            stream: tx,
+            pending: Default::default(),
+        }
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<ChatMessage> {
+        self.stream.subscribe()
+    }
+
+    pub async fn filter_message(&self, uuid: Uuid, message: String) {
+        let mut pending = self.pending.lock().await;
+        if let Some(tx) = pending.remove(&uuid) {
+            let _ = tx.send(message);
+        }
+    }
+
+    pub async fn handle_message(&self, player_id: u32, message: String, all: bool) -> String {
+        // if there are no active chat streams, return the message as is
+        if self.stream.receiver_count() == 0 {
+            return message;
+        }
+
+        let uuid = Uuid::new_v4();
+
+        // add to pending to corelate the message with filter requests
+        let (tx, rx) = oneshot::channel();
+        let mut pending = self.pending.lock().await;
+        pending.insert(uuid, tx);
+        mem::drop(pending); // drop mutex lock for now
+
+        // broadcast message to all clients
+        let chat_message = ChatMessage {
+            uuid: uuid.to_string(),
+            player_id,
+            message: message.clone(),
+            all,
+        };
+        if self.stream.send(chat_message).is_err() {
+            // all receivers are dropped, return message unfiltered
+            return message;
+        }
+
+        // wait for up to 16 milliseconds for a filter request from the client
+        let filtered_message = match timeout(Duration::from_millis(16), rx).await {
+            // Did not receive filter request for chat message within 16ms -> drop message
+            Err(_) => String::new(),
+            // Channel got closed.
+            Ok(Err(_)) => String::new(),
+            // Received filter request for message from client.
+            Ok(Ok(message)) => message,
+        };
+
+        // remove from pending
+        let mut pending = self.pending.lock().await;
+        pending.remove(&uuid);
+
+        filtered_message
+    }
+}


### PR DESCRIPTION
This PR adds a POC for filtering chat messages using the new access to the hook env.

An example client that converts all messages to uppercase can be run via `cargo run --example chat_filter`.

We might not wanna keep the POC though, see inline comments.