### PR TITLE
implement setting to limit throughput

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ GRPC = {
 
   -- whether debug logging is enabled or not
   debug = false,
+
+  -- limit of calls per second that are executed inside of the mission scripting environment
+  throughputLimit = 600,
 }
 ```
 

--- a/lua/grpc.lua
+++ b/lua/grpc.lua
@@ -91,6 +91,14 @@ GRPC.logWarning = function(err)
   env.warning("[GRPC] "..err)
 end
 
+GRPC.logInfo = function(msg)
+  grpc.log_info(msg)
+end
+
+GRPC.logDebug = function(msg)
+  grpc.log_debug(msg)
+end
+
 --- The client specified an invalid argument
 GRPC.errorInvalidArgument = function(msg)
   return {
@@ -205,14 +213,14 @@ local MISSION_ENV = 1
 local HOOK_ENV = 2
 
 -- Adjust the interval at which the gRPC server is polled for requests based on the throughput
--- limit. The higher the throughput, the more often the gRPC is polled per second.
+-- limit. The higher the throughput limit, the more often the gRPC is polled per second.
 local interval = math.max(0.03, math.min(1.0, 16 / GRPC.throughputLimit))
 local callsPerTick = math.ceil(GRPC.throughputLimit * interval)
 
 if isMissionEnv then
-  env.info(
+  GRPC.logInfo(
     "Limit request execution at max. " .. tostring(callsPerTick) .. " calls every " ..
-    tostring(interval) .. "s (≙ throughput of " .. tostring(GRPC.throughput) .. ")"
+    tostring(interval) .. "s (≙ throughput of " .. tostring(GRPC.throughputLimit) .. ")"
   )
 
   -- execute gRPC requests

--- a/src/hot_reload.rs
+++ b/src/hot_reload.rs
@@ -93,10 +93,34 @@ pub fn log_error(lua: &Lua, err: String) -> LuaResult<()> {
 pub fn log_warning(lua: &Lua, err: String) -> LuaResult<()> {
     if let Some(ref lib) = *LIBRARY.read().unwrap() {
         let f: Symbol<fn(lua: &Lua, err: String) -> LuaResult<()>> = unsafe {
-            lib.get(b"log_error")
+            lib.get(b"log_warning")
                 .map_err(|err| mlua::Error::ExternalError(Arc::new(err)))?
         };
         f(lua, err)
+    } else {
+        Ok(())
+    }
+}
+
+pub fn log_info(lua: &Lua, msg: String) -> LuaResult<()> {
+    if let Some(ref lib) = *LIBRARY.read().unwrap() {
+        let f: Symbol<fn(lua: &Lua, msg: String) -> LuaResult<()>> = unsafe {
+            lib.get(b"log_info")
+                .map_err(|err| mlua::Error::ExternalError(Arc::new(err)))?
+        };
+        f(lua, msg)
+    } else {
+        Ok(())
+    }
+}
+
+pub fn log_debug(lua: &Lua, msg: String) -> LuaResult<()> {
+    if let Some(ref lib) = *LIBRARY.read().unwrap() {
+        let f: Symbol<fn(lua: &Lua, msg: String) -> LuaResult<()>> = unsafe {
+            lib.get(b"log_debug")
+                .map_err(|err| mlua::Error::ExternalError(Arc::new(err)))?
+        };
+        f(lua, msg)
     } else {
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,6 +209,18 @@ pub fn log_warning(_: &Lua, err: String) -> LuaResult<()> {
     Ok(())
 }
 
+#[no_mangle]
+pub fn log_info(_: &Lua, err: String) -> LuaResult<()> {
+    log::info!("{}", err);
+    Ok(())
+}
+
+#[no_mangle]
+pub fn log_debug(_: &Lua, err: String) -> LuaResult<()> {
+    log::debug!("{}", err);
+    Ok(())
+}
+
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Failed to deserialize params: {0}")]
@@ -238,6 +250,8 @@ pub fn dcs_grpc_server_hot_reload(lua: &Lua) -> LuaResult<LuaTable> {
     )?;
     exports.set("log_error", lua.create_function(hot_reload::log_error)?)?;
     exports.set("log_warning", lua.create_function(hot_reload::log_warning)?)?;
+    exports.set("log_info", lua.create_function(hot_reload::log_info)?)?;
+    exports.set("log_debug", lua.create_function(hot_reload::log_debug)?)?;
     Ok(exports)
 }
 
@@ -252,6 +266,8 @@ pub fn dcs_grpc_server(lua: &Lua) -> LuaResult<LuaTable> {
     exports.set("on_chat_message", lua.create_function(on_chat_message)?)?;
     exports.set("log_error", lua.create_function(log_error)?)?;
     exports.set("log_warning", lua.create_function(log_warning)?)?;
+    exports.set("log_info", lua.create_function(log_info)?)?;
+    exports.set("log_debug", lua.create_function(log_debug)?)?;
     Ok(exports)
 }
 


### PR DESCRIPTION
Add setting to limit throughput of calls that are executing inside of the mission scripting environment.

More details in inline comments. I don't really have a use-case where I'd see a difference between a throughput of `1` and `1000`, so if you have one, it be worth testing it against this PR.

Refs #26