### PR TITLE
upgrade to Rust and Cargo 1.56

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[env]
+LUA_LIB_NAME = "lua"
+LUA_LIB = { value = "lua/lua5.1/", relative = true }
+LUA_INC = { value = "lua/lua5.1/include", relative = true }

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,13 +14,16 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    env:
-      LUA_LIB_NAME: lua
-      LUA_LIB: ${{ github.workspace }}/lua/lua5.1/
-      LUA_INC: ${{ github.workspace }}/lua/lua5.1/include
-
     steps:
     - uses: actions/checkout@v2
+
+    - name: Install stable toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+        components: rustfmt, clippy
 
     - name: Build
       run: cargo build

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .*
 !.gitignore
 !.github
+!.cargo
 /target
 Cargo.lock
 scratchpad.txt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,8 @@ name = "dcs-grpc-server"
 version = "0.1.0"
 authors = ["Markus Ast <m@rkusa.st>"]
 license = "AGPL-3.0-or-later"
-edition = "2018"
-resolver = "2"
+edition = "2021"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,9 @@
-build: export LUA_LIB_NAME=lua
-build: export LUA_LIB=$(CURDIR)/lua/lua5.1/
-build: export LUA_INC=$(CURDIR)/lua/lua5.1/include
 build:
 	cargo build --features hot-reload
 	powershell copy target/debug/dcs_grpc_server.dll target/debug/dcs_grpc_server_hot_reload.dll
 
-watch: export LUA_LIB_NAME=lua
-watch: export LUA_LIB=$(CURDIR)/lua/lua5.1/
-watch: export LUA_INC=$(CURDIR)/lua/lua5.1/include
 watch:
 	cargo watch -x "check --features hot-reload"
 
-test: export LUA_LIB_NAME=lua
-test: export LUA_LIB=$(CURDIR)/lua/lua5.1/
-test: export LUA_INC=$(CURDIR)/lua/lua5.1/include
 test:
 	cargo test

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The following section is only applicable to people who want to developer the DCS
 
 ### Build Dependencies
 
-- Rust `>=1.39`
+- Rust `>=1.56`
 - `rustfmt` (`rustup component add rustfmt`)
 
 ### Build
@@ -132,9 +132,6 @@ make build
 You may need to use the following in powershell
 
 ```
-$env:LUA_LIB_NAME="lua"
-$env:LUA_LIB=(Get-Item -Path ".\").FullName+"/lua/lua5.1/"
-$env:LUA_INC=(Get-Item -Path ".\").FullName+"/lua/lua5.1/include"
 cargo build
 ```
 


### PR DESCRIPTION
Upgrade to [Rust 1.56](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html).

You need to run `rustup update` to get the latest version.