### PR TITLE
include events and lock acquisition to stats

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -62,7 +62,7 @@ impl MissionRpc {
         I: serde::Serialize + Send + Sync + 'static,
         for<'de> O: serde::Deserialize<'de> + Send + Sync + std::fmt::Debug + 'static,
     {
-        let _guard = self.stats.track_queue();
+        let _guard = self.stats.track_queue_size();
         self.ipc
             .request(method, Some(request.into_inner()))
             .await
@@ -73,7 +73,7 @@ impl MissionRpc {
     where
         I: serde::Serialize + Send + Sync + 'static,
     {
-        let _guard = self.stats.track_queue();
+        let _guard = self.stats.track_queue_size();
         self.ipc
             .notification(method, Some(request.into_inner()))
             .await
@@ -100,7 +100,7 @@ impl HookRpc {
         I: serde::Serialize + Send + Sync + 'static,
         for<'de> O: serde::Deserialize<'de> + Send + Sync + std::fmt::Debug + 'static,
     {
-        let _guard = self.stats.track_queue();
+        let _guard = self.stats.track_queue_size();
         self.ipc
             .request(method, Some(request.into_inner()))
             .await
@@ -111,7 +111,7 @@ impl HookRpc {
     where
         I: serde::Serialize + Send + Sync + 'static,
     {
-        let _guard = self.stats.track_queue();
+        let _guard = self.stats.track_queue_size();
         self.ipc
             .notification(method, Some(request.into_inner()))
             .await


### PR DESCRIPTION
For changes see code comments.

Examples with this PR:

- Unit stream with a lot of units:
  ```
  2021-10-22 09:22:05.872 INFO    dcs_grpc_server::stats: Calls per second: average=344.93, highest=1211.69
  2021-10-22 09:22:05.872 INFO    dcs_grpc_server::stats: Events per second: average=0.00, highest=0.00
  2021-10-22 09:22:05.872 INFO    dcs_grpc_server::stats: Blocking time: total=363.8075ms (≙ 0.006%)
  2021-10-22 09:22:05.872 INFO    dcs_grpc_server::stats: Queue size: average=116.19, biggest=400
  ```
- Event stream with a lot of events
  ```
  2021-10-22 09:31:10.353 INFO    dcs_grpc_server::stats: Calls per second: average=129.13, highest=186.71
  2021-10-22 09:31:10.353 INFO    dcs_grpc_server::stats: Events per second: average=47.23, highest=98.48
  2021-10-22 09:31:10.353 INFO    dcs_grpc_server::stats: Blocking time: total=445.517ms (≙ 0.007%)
  2021-10-22 09:31:10.353 INFO    dcs_grpc_server::stats: Queue size: average=0.00, biggest=0
  ```

