### PR TITLE
fix clippy warnings and add clippy to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,5 +34,8 @@ jobs:
     - name: Run tests
       run: cargo test
 
+    - name: Run clippy
+      run: cargo clippy -- -D warnings
+
     - name: Check formatting
       run: cargo fmt -- --check

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -7,11 +7,6 @@ pub struct Chat {
 }
 
 impl Chat {
-    pub fn new() -> Self {
-        let (tx, _) = broadcast::channel(128);
-        Self { stream: tx }
-    }
-
     pub fn subscribe(&self) -> broadcast::Receiver<ChatMessage> {
         self.stream.subscribe()
     }
@@ -25,9 +20,16 @@ impl Chat {
         self.stream
             .send(ChatMessage {
                 player_id,
-                message: message.clone(),
+                message,
                 all,
             })
             .ok();
+    }
+}
+
+impl Default for Chat {
+    fn default() -> Self {
+        let (tx, _) = broadcast::channel(128);
+        Self { stream: tx }
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -45,7 +45,7 @@ impl Server {
             ipc_mission,
             ipc_hook,
             runtime,
-            chat: Chat::new(),
+            chat: Chat::default(),
             stats: Stats::new(shutdown.handle()),
             shutdown,
             after_shutdown: None,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -54,15 +54,14 @@ pub async fn stream_units(
     )
     .await?
     .into_iter()
-    .flatten()
-    .collect::<Vec<_>>();
+    .flatten();
 
     let group_units = futures_util::future::try_join_all(groups.into_iter().map(|group| {
         state
             .ctx
             .rpc
             .get_units(Request::new(GetUnitsRequest {
-                group_name: group.name.clone(),
+                group_name: group.name,
                 active: Some(true),
             }))
             .map_ok(|res| res.into_inner().units)


### PR DESCRIPTION
Adding Clippy (Rust's linter) to CI and forbid warnings.