### PR TITLE
implement eval method for hook env

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ rust-version = "1.56"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+clap = "3.0.0-beta.5"
 dcs-module-ipc = "0.5"
 futures-util = "0.3"
 libloading = { version = "0.7", optional = true }

--- a/lua/grpc.lua
+++ b/lua/grpc.lua
@@ -45,7 +45,12 @@ else
 end
 
 if isMissionEnv then
-  grpc.start(GRPC.host, GRPC.port, GRPC.debug)
+  grpc.start({
+    host = GRPC.host,
+    port = GRPC.port,
+    debug = GRPC.debug,
+    evalEnabled = GRPC.evalEnabled
+  })
 end
 
 --
@@ -81,18 +86,33 @@ end
 -- Logging methods
 --
 
-GRPC.logError = function(err)
-  grpc.logError(err)
-  env.error("[GRPC] "..err)
+GRPC.logError = function(msg)
+  grpc.logError(msg)
+
+  if isMissionEnv then
+    env.error("[GRPC] "..msg)
+  else
+    log.write("[GRPC-Hook]", log.ERROR, msg)
+  end
 end
 
-GRPC.logWarning = function(err)
-  grpc.logWarning(err)
-  env.warning("[GRPC] "..err)
+GRPC.logWarning = function(msg)
+  grpc.logWarning(msg)
+
+  if isMissionEnv then
+    env.info("[GRPC] "..msg)
+  else
+    log.write("[GRPC-Hook]", log.WARNING, msg)
+  end
 end
 
 GRPC.logInfo = function(msg)
   grpc.logInfo(msg)
+  if isMissionEnv then
+    env.info("[GRPC] "..msg)
+  else
+    log.write("[GRPC-Hook]", log.INFO, msg)
+  end
 end
 
 GRPC.logDebug = function(msg)

--- a/lua/methods/custom.lua
+++ b/lua/methods/custom.lua
@@ -10,11 +10,7 @@ GRPC.methods.joinMission = function(params)
     return GRPC.errorUnimplemented("This method is not implemented")
 end
 
-GRPC.methods.eval = function(params)
-    if GRPC.evalEnabled ~= true then
-        return GRPC.errorPermissionDenied("eval operation is disabled")
-    end
-
+GRPC.methods.missionEval = function(params)
     local fn, err = loadstring(params.lua)
     if not fn then
         return GRPC.error("Failed to load Lua code: "..err)

--- a/lua/methods/hook.lua
+++ b/lua/methods/hook.lua
@@ -8,3 +8,17 @@ local GRPC = GRPC
 GRPC.methods.getMissionName = function()
   return GRPC.success({name = DCS.getMissionName()})
 end
+
+GRPC.methods.hookEval = function(params)
+  local fn, err = loadstring(params.lua)
+  if not fn then
+    return GRPC.error("Failed to load Lua code: "..err)
+  end
+
+  local ok, result = pcall(fn)
+  if not ok then
+    return GRPC.error("Failed to execute Lua code: "..result)
+  end
+
+  return GRPC.success(result)
+end

--- a/protos/dcs.proto
+++ b/protos/dcs.proto
@@ -137,6 +137,10 @@ service Hook {
 
 	// Stream all chat messages.
 	rpc StreamChat(dcs.hook.StreamChatRequest) returns (stream dcs.hook.ChatMessage) {}
+
+	// Evaluate some Lua inside of the hook environment and return the result as a JSON string.
+	// Disabled by default.
+	rpc Eval(EvalRequest) returns (EvalResponse) {}
 }
 
 // https://wiki.hoggitworld.com/view/DCS_Class_Unit

--- a/src/hot_reload.rs
+++ b/src/hot_reload.rs
@@ -10,8 +10,8 @@ use once_cell::sync::Lazy;
 
 static LIBRARY: Lazy<RwLock<Option<Library>>> = Lazy::new(|| RwLock::new(None));
 
-pub fn start(lua: &Lua, args: (String, u16, bool)) -> LuaResult<()> {
-    let write_dir = super::init(lua, args.2)?;
+pub fn start(lua: &Lua, config: Value) -> LuaResult<()> {
+    let write_dir = super::write_dir(lua)?;
     let lib_path = write_dir.clone() + "Mods/Tech/DCS-gRPC/dcs_grpc_server.dll";
 
     let new_lib = unsafe { Library::new(lib_path) }.map_err(|err| {
@@ -21,11 +21,11 @@ pub fn start(lua: &Lua, args: (String, u16, bool)) -> LuaResult<()> {
     let mut lib = LIBRARY.write().unwrap();
     let lib = lib.get_or_insert(new_lib);
 
-    let f: Symbol<fn(lua: &Lua, args: (String, u16, bool)) -> LuaResult<()>> = unsafe {
+    let f: Symbol<fn(lua: &Lua, config: Value) -> LuaResult<()>> = unsafe {
         lib.get(b"start")
             .map_err(|err| mlua::Error::ExternalError(Arc::new(err)))?
     };
-    let result = f(lua, args);
+    let result = f(lua, config);
 
     result
 }


### PR DESCRIPTION
Implement eval for the hook env (in addition to the mission env).
Additional changes:
- Add flag to repl to switch between mission and hook env (`--env mission` and `--env hook`, `mission` being the default).
- Refactor some code (highlighted with inline comments).



With `GRPC.evalEnabled = false`:

```bash
$ .\target\debug\repl.exe --env=mission
return type(DCS)
status: PermissionDenied, message: "eval operation is disabled", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Sat, 23 Oct 2021 21:18:18 GMT"} }
$ .\target\debug\repl.exe --env=hook
return type(DCS)
status: PermissionDenied, message: "eval operation is disabled", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Sat, 23 Oct 2021 21:18:23 GMT"} }
```

With `GRPC.evalEnabled = true`:

```bash
$ .\target\debug\repl.exe --env=mission
return type(DCS)
= nil
$ .\target\debug\repl.exe --env=hook
return type(DCS)
= table
```