### PR TITLE
Split Atmosphere APIs into separate grpc package

### DIFF
--- a/protos/atmosphere.proto
+++ b/protos/atmosphere.proto
@@ -2,13 +2,25 @@ syntax = "proto3";
 
 import "common.proto";
 
-package dcs;
+package dcs.atmosphere;
+
+// https://wiki.hoggitworld.com/view/DCS_singleton_atmosphere
+service AtmosphereService {
+	// https://wiki.hoggitworld.com/view/DCS_func_getWind
+	rpc GetWind(atmosphere.GetWindRequest) returns (atmosphere.GetWindResponse) {}
+
+	// https://wiki.hoggitworld.com/view/DCS_func_getWindWithTurbulence
+	rpc GetWindWithTurbulence(atmosphere.GetWindWithTurbulenceRequest) returns (atmosphere.GetWindWithTurbulenceResponse) {}
+
+	// https://wiki.hoggitworld.com/view/DCS_func_getWindWithTurbulence
+	rpc GetTemperatureAndPressure(atmosphere.GetTemperatureAndPressureRequest) returns (atmosphere.GetTemperatureAndPressureResponse) {}
+}
 
 message GetWindRequest {
 	// The position on the map we want the wind information for.
 	// Requires lat/lon/alt fields to be populated, there are
 	// no default values
-	Position position = 1;
+	dcs.Position position = 1;
 }
 
 message GetWindResponse {
@@ -22,7 +34,7 @@ message GetWindWithTurbulenceRequest {
 	// The position on the map we want the wind information for.
 	// Requires lat/lon/alt fields to be populated, there are
 	// no default values
-	Position position = 1;
+	dcs.Position position = 1;
 }
 
 message GetWindWithTurbulenceResponse {
@@ -36,7 +48,7 @@ message GetTemperatureAndPressureRequest {
 	// The position on the map we want the wind information for.
 	// Requires lat/lon/alt fields to be populated, there are
 	// no default values
-	Position position = 1;
+	dcs.Position position = 1;
 }
 
 message GetTemperatureAndPressureResponse {

--- a/protos/dcs.proto
+++ b/protos/dcs.proto
@@ -15,18 +15,6 @@ import "world.proto";
 
 package dcs;
 
-// https://wiki.hoggitworld.com/view/DCS_singleton_atmosphere
-service Atmosphere {
-	// https://wiki.hoggitworld.com/view/DCS_func_getWind
-	rpc GetWind(GetWindRequest) returns (GetWindResponse) {}
-
-	// https://wiki.hoggitworld.com/view/DCS_func_getWindWithTurbulence
-	rpc GetWindWithTurbulence(GetWindWithTurbulenceRequest) returns (GetWindWithTurbulenceResponse) {}
-
-	// https://wiki.hoggitworld.com/view/DCS_func_getWindWithTurbulence
-	rpc GetTemperatureAndPressure(GetTemperatureAndPressureRequest) returns (GetTemperatureAndPressureResponse) {}
-}
-
 // https://wiki.hoggitworld.com/view/DCS_singleton_coalition
 service Coalitions {
 	// https://wiki.hoggitworld.com/view/DCS_func_getPlayers

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 use crate::chat::Chat;
 use crate::shutdown::{AbortableStream, ShutdownHandle};
 use crate::stats::Stats;
-use dcs::atmosphere_server::Atmosphere;
+use dcs::atmosphere::atmosphere_service_server::AtmosphereService;
 use dcs::coalitions_server::Coalitions;
 use dcs::controllers_server::Controllers;
 use dcs::custom_server::Custom;
@@ -23,6 +23,10 @@ use tonic::{Request, Response, Status};
 
 pub mod dcs {
     tonic::include_proto!("dcs");
+
+    pub mod atmosphere {
+        tonic::include_proto!("dcs.atmosphere");
+    }
 
     pub mod group {
         tonic::include_proto!("dcs.group");
@@ -309,29 +313,29 @@ impl Triggers for MissionRpc {
 }
 
 #[tonic::async_trait]
-impl Atmosphere for MissionRpc {
+impl AtmosphereService for MissionRpc {
     async fn get_wind(
         &self,
-        request: Request<GetWindRequest>,
-    ) -> Result<Response<GetWindResponse>, Status> {
-        let res: GetWindResponse = self.request("getWind", request).await?;
+        request: Request<atmosphere::GetWindRequest>,
+    ) -> Result<Response<atmosphere::GetWindResponse>, Status> {
+        let res: atmosphere::GetWindResponse = self.request("getWind", request).await?;
         Ok(Response::new(res))
     }
 
     async fn get_wind_with_turbulence(
         &self,
-        request: Request<GetWindWithTurbulenceRequest>,
-    ) -> Result<Response<GetWindWithTurbulenceResponse>, Status> {
-        let res: GetWindWithTurbulenceResponse =
+        request: Request<atmosphere::GetWindWithTurbulenceRequest>,
+    ) -> Result<Response<atmosphere::GetWindWithTurbulenceResponse>, Status> {
+        let res: atmosphere::GetWindWithTurbulenceResponse =
             self.request("getWindWithTurbulence", request).await?;
         Ok(Response::new(res))
     }
 
     async fn get_temperature_and_pressure(
         &self,
-        request: Request<GetTemperatureAndPressureRequest>,
-    ) -> Result<Response<GetTemperatureAndPressureResponse>, Status> {
-        let res: GetTemperatureAndPressureResponse =
+        request: Request<atmosphere::GetTemperatureAndPressureRequest>,
+    ) -> Result<Response<atmosphere::GetTemperatureAndPressureResponse>, Status> {
+        let res: atmosphere::GetTemperatureAndPressureResponse =
             self.request("getTemperatureAndPressure", request).await?;
         Ok(Response::new(res))
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,7 +6,7 @@ use crate::chat::Chat;
 use crate::rpc::{dcs, HookRpc, MissionRpc};
 use crate::shutdown::{Shutdown, ShutdownHandle};
 use crate::stats::Stats;
-use dcs::atmosphere_server::AtmosphereServer;
+use dcs::atmosphere::atmosphere_service_server::AtmosphereServiceServer;
 use dcs::coalitions_server::CoalitionsServer;
 use dcs::controllers_server::ControllersServer;
 use dcs::custom_server::CustomServer;
@@ -166,7 +166,7 @@ async fn try_run(
     }
 
     transport::Server::builder()
-        .add_service(AtmosphereServer::new(mission_rpc.clone()))
+        .add_service(AtmosphereServiceServer::new(mission_rpc.clone()))
         .add_service(CoalitionsServer::new(mission_rpc.clone()))
         .add_service(ControllersServer::new(mission_rpc.clone()))
         .add_service(CustomServer::new(mission_rpc.clone()))


### PR DESCRIPTION
Split the Atmosphere APIs including the service definition into a
separate gRPC package. This commit is the proof-of-concept for how we
will split all the different packages (unit, trigger, world, common) in
upcoming commits. Splitting everything into their own packages removes
problems where duplication is not possible (e.g. the `SetEmission` API
which exists in both `Unit` and `Group` services)