### PR TITLE
add custom.GetMagneticDeclination method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.43",
  "winapi",
 ]
 
@@ -159,10 +159,10 @@ dependencies = [
 name = "dcs-grpc"
 version = "0.1.0"
 dependencies = [
- "chrono",
  "dcs-grpc-stubs",
  "dcs-module-ipc",
  "futures-util",
+ "igrf",
  "libloading",
  "log",
  "log4rs",
@@ -172,6 +172,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "time 0.3.4",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -479,6 +480,16 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "igrf"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb750ac62b7b81c05b0090d0fc42cdab0ec685835ee6a83a51aad21a15fc79a"
+dependencies = [
+ "thiserror",
+ "time 0.3.4",
 ]
 
 [[package]]
@@ -1166,6 +1177,16 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99beeb0daeac2bd1e86ac2c21caddecb244b39a093594da1a661ec2060c7aedd"
+dependencies = [
+ "itoa",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,9 @@ members = [
 crate-type = ["cdylib"]
 
 [dependencies]
-chrono = "0.4"
-stubs = { package = "dcs-grpc-stubs", version = "0.1", path = "./stubs", features = ["server"] }
 dcs-module-ipc = "0.5"
 futures-util = "0.3"
+igrf = "0.2"
 libloading = { version = "0.7", optional = true }
 log4rs = "1.0"
 log = "0.4"
@@ -28,7 +27,9 @@ once_cell = "1.4.0"
 pin-project = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+stubs = { package = "dcs-grpc-stubs", version = "0.1", path = "./stubs", features = ["server"] }
 thiserror = "1.0"
+time = { version = "0.3", features = ["formatting", "parsing"] }
 tokio = { version = "1.0", features = ["rt-multi-thread", "time", "sync"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tonic = "0.6"

--- a/protos/custom.proto
+++ b/protos/custom.proto
@@ -17,9 +17,11 @@ service CustomService {
   // Disabled by default.
   rpc Eval(EvalRequest) returns (EvalResponse) {}
 
-  /// Calculates the magnetic declination at the given position using the International Geomagnetic
-  /// Reference Field (IGRF) model. The result is not always exactly the same as what DCS seem to
-  /// use, but it is very close (DCS doesn't expose its declination).
+  /**
+   * Calculates the magnetic declination at the given position using the International Geomagnetic
+   * Reference Field (IGRF) model. The result is not always exactly the same as what DCS seem to
+   * use, but it is very close (DCS doesn't expose its declination).
+   */
   rpc GetMagneticDeclination(GetMagneticDeclinationRequest) returns (GetMagneticDeclinationResponse) {}
 }
 

--- a/protos/custom.proto
+++ b/protos/custom.proto
@@ -16,6 +16,11 @@ service CustomService {
   // Evaluate some Lua inside of the mission and return the result as a JSON string.
   // Disabled by default.
   rpc Eval(EvalRequest) returns (EvalResponse) {}
+
+  /// Calculates the magnetic declination at the given position using the International Geomagnetic
+  /// Reference Field (IGRF) model. The result is not always exactly the same as what DCS seem to
+  /// use, but it is very close (DCS doesn't expose its declination).
+  rpc GetMagneticDeclination(GetMagneticDeclinationRequest) returns (GetMagneticDeclinationResponse) {}
 }
 
 message MissionAssignmentRequest {
@@ -38,4 +43,20 @@ message EvalRequest {
 
 message EvalResponse {
   string json = 1;
+}
+
+message GetMagneticDeclinationRequest {
+  /// Latitude in Decimal Degrees format
+  double lat = 1;
+  /// Longitude in Decimal Degrees format
+  double lon = 2;
+  /// Altitude in Meters above Mean Sea Level (MSL)
+  double alt = 3;
+}
+
+message GetMagneticDeclinationResponse {
+  /// Magnetic declination in degrees. A negative value is an westerly declination, while a positive
+  /// value is a easterly declination.
+  /// `True North` + `declination` = `Magnetic North`
+  double declination = 1;
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,9 +1,12 @@
+use std::sync::Arc;
+
 use crate::chat::Chat;
 use crate::shutdown::ShutdownHandle;
 use crate::stats::Stats;
 use dcs_module_ipc::IPC;
 use futures_util::Stream;
 use stubs::mission::Event;
+use tokio::sync::RwLock;
 use tonic::{Request, Status};
 
 mod atmosphere;
@@ -24,6 +27,12 @@ pub struct MissionRpc {
     stats: Stats,
     eval_enabled: bool,
     shutdown_signal: ShutdownHandle,
+    cache: Arc<RwLock<Cache>>,
+}
+
+#[derive(Default)]
+struct Cache {
+    scenario_start_time: Option<time::OffsetDateTime>,
 }
 
 #[derive(Clone)]
@@ -42,6 +51,7 @@ impl MissionRpc {
             stats,
             eval_enabled: false,
             shutdown_signal,
+            cache: Default::default(),
         }
     }
 


### PR DESCRIPTION
Add `custom.GetMagneticDeclination` method which calculates the magnetic declination for a given lat, lon and alt.

DCS isn't exposing the declination, which is why I've implemented _International Geomagnetic Reference Field (IGRF)_ in [igrf ](https://github.com/rkusa/igrf) for [DATIS](https://github.com/rkusa/DATIS) a while ago. While the calculated declination is not always 100% exactly what DCS uses, it is very close and I'd say close enough (I think the difference is mainly due to my `igrf` using newer source date than DCS).

This PR is mainly a result of the thought that this might be useful for others, too. Wdyt, does this make sense to have as part of DCS-gRPC?

Example:
```
> .\grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs.proto -d '{\"lat\":42.0252750,\"lon\":40.0473825,\"alt\":0.0}' 127.0.0.1:50051 dcs.custom.CustomService/GetMagneticDeclination
{
  "declination": -6.46
}
```