### PR TITLE
Proof of Concept for Enum renumbering

### DIFF
--- a/lua/methods/trigger.lua
+++ b/lua/methods/trigger.lua
@@ -99,6 +99,8 @@ GRPC.methods.explosion = function(params)
   return GRPC.success(nil)
 end
 
+-- gRPC enums should avoid 0 so we increment it there and then subtract by 1
+-- here since this enum is zero indexed.
 GRPC.methods.smoke = function(params)
   local point = coord.LLtoLO(params.position.lat, params.position.lon, 0)
   local groundPoint = {
@@ -107,7 +109,7 @@ GRPC.methods.smoke = function(params)
     z = point.z
   }
 
-  trigger.action.smoke(groundPoint, params.color)
+  trigger.action.smoke(groundPoint, params.color - 1)
 
   return GRPC.success(nil)
 end

--- a/protos/dcs/trigger/trigger.proto
+++ b/protos/dcs/trigger/trigger.proto
@@ -145,11 +145,12 @@ message SmokeRequest {
   // Putting this inside the request because we cannot
   // have the same enum value in the same package.
   enum SmokeColor {
-    SMOKE_COLOR_GREEN = 0;
-    SMOKE_COLOR_RED = 1;
-    SMOKE_COLOR_WHITE = 2;
-    SMOKE_COLOR_ORANGE = 3;
-    SMOKE_COLOR_BLUE = 4;
+    SMOKE_COLOR_UNSPECIFIED = 0;
+    SMOKE_COLOR_GREEN = 1;
+    SMOKE_COLOR_RED = 2;
+    SMOKE_COLOR_WHITE = 3;
+    SMOKE_COLOR_ORANGE = 4;
+    SMOKE_COLOR_BLUE = 5;
   }
 
   // Altitude parameter will be ignored. Smoke always eminates from ground


### PR DESCRIPTION
gRPC does not recommend zero indexed Enums but DCS uses them a lot.
Therefore this commit is a proof-of-concept for the easiest workaround I
can think of.

Pros: Simple.
Cons: All lua using these enums will have to remember to -1 when the DCS
enum is zero indexed (which is not all of them).

This change does not preclude an alternative option being made later. We can still do the gRPC enum renumbering now and come up with a better back-end implementation to replace `-1` in lua later.