### PR TITLE
Update coalition enum

### DIFF
--- a/lua/exporters/object.lua
+++ b/lua/exporters/object.lua
@@ -19,7 +19,7 @@ GRPC.exporters.unit = function(unit)
     id = tonumber(unit:getID()),
     name = unit:getName(),
     callsign = unit:getCallsign(),
-    coalition = unit:getCoalition(),
+    coalition = unit:getCoalition() + 1, -- Increment for non zero-indexed gRPC enum
     type = unit:getTypeName(),
     position = GRPC.toLatLonPosition(unit:getPoint()),
     playerName = Unit.getPlayerName(unit),
@@ -34,7 +34,7 @@ GRPC.exporters.group = function(group)
   return {
     id = tonumber(group:getID()),
     name = group:getName(),
-    coalition = group:getCoalition(),
+    coalition = group:getCoalition() + 1, -- Increment for non zero-indexed gRPC enum
     category = group:getCategory(),
   }
 end
@@ -55,7 +55,7 @@ GRPC.exporters.airbase = function(airbase)
   local a = {
     name = airbase:getName(),
     callsign = airbase:getCallsign(),
-    coalition = airbase:getCoalition(),
+    coalition = airbase:getCoalition() + 1, -- Increment for non zero-indexed gRPC enum
     category = airbase:getDesc()['category'],
     displayName = airbase:getDesc()['displayName'],
     position = GRPC.toLatLonPosition(airbase:getPoint())
@@ -95,7 +95,7 @@ GRPC.exporters.markPanel = function(markPanel)
   }
 
   if (markPanel.coalition >= 0 and markPanel.coalition <= 2) then
-    mp["coalition"] = markPanel.coalition;
+    mp["coalition"] = markPanel.coalition + 1; -- Increment for non zero-indexed gRPC enum
   end
 
   if (markPanel.groupID > 0) then

--- a/lua/methods/coalitions.lua
+++ b/lua/methods/coalitions.lua
@@ -7,10 +7,16 @@ local GRPC = GRPC
 local coalition = coalition
 
 GRPC.methods.getPlayers = function(params)
-  local units = coalition.getPlayers(params.coalition)
   local result = {}
-  for i, unit in ipairs(units) do
-    result[i] = GRPC.exporters.unit(unit)
+  for _, c in pairs(coalition.side) do
+    if params.coalition == 0 or params.coalition - 1 == c then -- Decrement for non zero-indexed gRPC enum
+      -- https://wiki.hoggitworld.com/view/DCS_func_getPlayers
+      local units = coalition.getPlayers(c)
+
+      for _, unit in ipairs(units) do
+        table.insert(result, GRPC.exporters.unit(unit))
+      end
+    end
   end
   return GRPC.success({units = result})
 end
@@ -18,7 +24,7 @@ end
 GRPC.methods.getGroups = function(params)
   local result = {}
   for _, c in pairs(coalition.side) do
-    if params.coalition == nil or params.coalition == c then
+    if params.coalition == 0 or params.coalition - 1 == c then -- Decrement for non zero-indexed gRPC enum
       -- https://wiki.hoggitworld.com/view/DCS_func_getGroups
       local groups = coalition.getGroups(c, params.category)
 
@@ -31,8 +37,14 @@ GRPC.methods.getGroups = function(params)
   return GRPC.success({groups = result})
 end
 
+-- This method should be called once per coalition per mission so using COALITION_ALL to save 2
+-- API calls is not worth the extra code.
 GRPC.methods.getMainReferencePoint = function(params)
-  local referencePoint = coalition.getMainRefPoint(params.coalition)
+  if params.coalition == 0 then
+    return GRPC.errorInvalidArgument("a specific coalition must be chosen")
+  end
+
+  local referencePoint = coalition.getMainRefPoint(params.coalition - 1) -- Decrement for non zero-indexed gRPC enum
 
   return GRPC.success({
     position = GRPC.toLatLonPosition(referencePoint)

--- a/lua/methods/mission.lua
+++ b/lua/methods/mission.lua
@@ -286,7 +286,7 @@ GRPC.onDcsEvent = function(event)
     if event.groupID > -1 and event.groupID then
       payload.groupId = event.groupId
     elseif event.coalition > -1 and event.coalition then
-      payload.coalition = event.coalition
+      payload.coalition = event.coalition + 1  -- Increment for non zero-indexed gRPC enum
     end
     return {
       time = event.time,
@@ -304,7 +304,7 @@ GRPC.onDcsEvent = function(event)
     if event.groupID > -1 and event.groupID then
       payload.groupId = event.groupId
     elseif event.coalition > -1 and event.coalition then
-      payload.coalition = event.coalition
+      payload.coalition = event.coalition + 1 -- Increment for non zero-indexed gRPC enum
     end
     return {
       time = event.time,
@@ -322,7 +322,7 @@ GRPC.onDcsEvent = function(event)
     if event.groupID > -1 and event.groupID then
       payload.groupId = event.groupId
     elseif event.coalition > -1 and event.coalition then
-      payload.coalition = event.coalition
+      payload.coalition = event.coalition + 1 -- Increment for non zero-indexed gRPC enum
     end
     return {
       time = event.time,

--- a/lua/methods/trigger.lua
+++ b/lua/methods/trigger.lua
@@ -30,7 +30,12 @@ GRPC.methods.outText = function(params)
 end
 
 GRPC.methods.outTextForCoalition = function(params)
-  trigger.action.outTextForCoalition(params.coalition, params.text, params.displayTime, params.clearView)
+  if params.coalition == 0 then
+    return GRPC.errorInvalidArgument("a specific coalition must be chosen")
+  end
+
+  -- Decrement for non zero-indexed gRPC enum
+  trigger.action.outTextForCoalition(params.coalition - 1, params.text, params.displayTime, params.clearView)
 
   return GRPC.success(nil)
 end

--- a/lua/methods/world.lua
+++ b/lua/methods/world.lua
@@ -10,14 +10,14 @@ local GRPC = GRPC
 GRPC.methods.getAirbases = function(params)
   local data
 
-  if params.coalition == nil then
+  if params.coalition == 0 then
     data = world.getAirbases()
   else
     -- Yes, yes, this is in the world file but uses coalition. I plan
     -- to completely rejigger the organisation of these files when we
     -- have more APIs implemented and amore sane pattern presents
     -- itself. For the moment we are mostly following DCS organisation
-    data = coalition.getAirbases(params.coalition)
+    data = coalition.getAirbases(params.coalition - 1)  -- Decrement for non zero-indexed gRPC enum
   end
 
   local result = {}

--- a/protos/dcs/coalition/coalition.proto
+++ b/protos/dcs/coalition/coalition.proto
@@ -24,6 +24,8 @@ service CoalitionService {
 }
 
 message GetMainReferencePointRequest {
+  // A specific coalition must be used for this API call. Do not use
+  // `COALITION_ALL`
   dcs.common.Coalition coalition = 1;
 }
 

--- a/protos/dcs/common/common.proto
+++ b/protos/dcs/common/common.proto
@@ -40,9 +40,11 @@ enum AirbaseCategory {
  * one and may not be as supported as the belligerant ones.
  */
 enum Coalition {
-  COALITION_NEUTRAL = 0;
-  COALITION_RED = 1;
-  COALITION_BLUE = 2;
+  // protolint:disable:next ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH
+  COALITION_ALL = 0;
+  COALITION_NEUTRAL = 1;
+  COALITION_RED = 2;
+  COALITION_BLUE = 3;
 }
 
 /**

--- a/protos/dcs/world/world.proto
+++ b/protos/dcs/world/world.proto
@@ -12,7 +12,7 @@ service WorldService {
 }
 
 message GetAirbasesRequest {
-  optional dcs.common.Coalition coalition = 1;
+  dcs.common.Coalition coalition = 1;
 }
 
 message GetAirbasesResponse {

--- a/stubs/src/lib.rs
+++ b/stubs/src/lib.rs
@@ -67,6 +67,9 @@ mod tests {
         );
     }
 
+    // Note that this string sumulates the response from Lua. This is important as it is
+    // _after_ increment changes to enums to cater to gRPC enum indexing where 0 is not allowed
+    // for responses.
     #[test]
     fn test_enum_deserialization() {
         let event: StreamEventsResponse = serde_json::from_str(
@@ -81,7 +84,7 @@ mod tests {
                                     "id": 1,
                                     "name": "Aerial-1-1",
                                     "callsign": "Enfield11",
-                                    "coalition": 2,
+                                    "coalition": 3,
                                     "type": "FA-18C_hornet",
                                     "position": {
                                         "lat": 3,
@@ -97,7 +100,7 @@ mod tests {
                                 }
                             }
 		                },
-		                "coalition": 2,
+		                "coalition": 3,
 		                "id": 42,
 		                "position": {
 			                "lat": 1,
@@ -152,6 +155,9 @@ mod tests {
         );
     }
 
+    // Note that this string sumulates the response from Lua. This is important as it is
+    // _after_ increment changes to enums to cater to gRPC enum indexing where 0 is not allowed
+    // for responses.
     #[test]
     fn test_optional_field_deserialization() {
         let resp: GetAirbasesResponse = serde_json::from_str(
@@ -160,7 +166,7 @@ mod tests {
                 {
                     "airbases": [
                         {
-                            "coalition": 0,
+                            "coalition": 1,
                             "name": "Anapa-Vityazevo",
                             "callsign": "Anapa-Vityazevo",
                             "position": {


### PR DESCRIPTION
Update the coalition enum to add COALITION_UNSPECIFIED.

We can actually use this new value in some APIs where specifying the
coalition was optional.

I am putting this change up as a PR because it is quite big so want a sanity check.