### PR TITLE
add category to common.v0.Unit

### DIFF
--- a/lua/exporters/object.lua
+++ b/lua/exporters/object.lua
@@ -45,7 +45,8 @@ GRPC.exporters.unit = function(unit)
     groupName = Unit.getGroup(unit):getName(),
     numberInGroup = unit:getNumber(),
     heading = heading,
-    speed = speed
+    speed = speed,
+    category = unit:getGroup():getCategory(),
   }
 end
 

--- a/protos/dcs/common/v0/common.proto
+++ b/protos/dcs/common/v0/common.proto
@@ -212,6 +212,8 @@ message Unit {
   double speed = 10;
   // The heading of the unit
   double heading = 11;
+  // The group category.
+  GroupCategory category = 12;
 }
 
 /**

--- a/stubs/src/lib.rs
+++ b/stubs/src/lib.rs
@@ -120,7 +120,8 @@ mod tests {
                                     "groupName": "Group 1",
                                     "numberInGroup": 1,
                                     "heading": 0.5,
-                                    "speed": 0.8
+                                    "speed": 0.8,
+                                    "category": 0
                                 }
                             }
 		                },
@@ -159,7 +160,8 @@ mod tests {
                             group_name: "Group 1".to_string(),
                             number_in_group: 1,
                             heading: 0.5,
-                            speed: 0.8
+                            speed: 0.8,
+                            category: 0,
                         }))
                     }),
                     visibility: Some(event::mark_add_event::Visibility::Coalition(


### PR DESCRIPTION
I had it a second time today, that I had to fetch the group of a unit just to get it's category, which is why I'd propose to always add the category to the units.

Any objections?