### PR TITLE
Airplane Group Spawning

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -19,4 +19,6 @@ read_globals = {
   "trigger",
   "Unit",
   "world",
+  "Airbase",
+  "country"
 }

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -20,5 +20,4 @@ read_globals = {
   "Unit",
   "world",
   "Airbase",
-  "country"
 }

--- a/lua/methods/coalitions.lua
+++ b/lua/methods/coalitions.lua
@@ -256,7 +256,7 @@ GRPC.methods.addGroup = function(params)
   end
   local template
   if params.template.type == "Airplane" then
-    template = createPlaneGroupTemplate(params.template.groupTemplate)
+    template = createPlaneGroupTemplate(params.template.airplaneTemplate)
   elseif params.template.type == "Ground" then
     template = createGroundGroupTemplate(params.template.groundTemplate)
   end

--- a/lua/methods/coalitions.lua
+++ b/lua/methods/coalitions.lua
@@ -21,12 +21,157 @@ local skill = {
   Player = 5
 }
 
+-- types for aircraft taking off
+local takeoffTypes = {
+  [1] = "TakeOff",
+  [2] = "TakeOffParking",
+  [3] = "TakeOffParkingHot",
+  [4] = "Turning Point",
+  runway = "TakeOff",
+  cold = "TakeOffParking",
+  hot = "TakeOffParkingHot",
+  air = "Turning Point"
+}
+
+-- actiions for aircraft taking off
+local takeoffActions = {
+  [1] = "From Runway",
+  [2] = "From Parking Area",
+  [3] = "From Parking Area Hot",
+  [4] = "Turning Point",
+  runway = "From Runway",
+  cold = "From Parking Area",
+  hot = "From Parking Area Hot",
+  air = "Turning Point",
+}
+
 --local altitudeType = {
 --  [1] = "BARO",
 --  [2] = "RADIO",
 --  BARO = 1,
 --  RADIO = 2
 --}
+
+local buildAirplanePoints = function(points)
+  local builtPoints = {}
+  for _, pointData in pairs(points) do
+    local pointVec3
+    if type(pointData.place) == "string" then
+      if Airbase.getByName(pointData.place) then
+        pointVec3 = Airbase.getByName(pointData.place):getPoint()
+        env.info("ab point type")
+      elseif trigger.misc.getZone(pointData.place) then
+        pointVec3 = trigger.misc.getZone(pointData.place).point
+        env.info("zone point type")
+      end
+    elseif type(pointData.place) == "table" then
+      pointVec3 = coord.LLtoLO(pointData.place.lat, pointData.place.lon)
+    end
+    builtPoints[#builtPoints+1] = {
+      alt = pointData.alt,
+      x = pointVec3.x,
+      y = pointVec3.z,
+      type = pointData.type or takeoffTypes.air,
+      eta = 0,
+      eta_locked = true,
+      alt_type = pointData.alt_type or "BARO",
+      formation_template = "",
+      speed = pointData.speed,
+      action = pointData.action or takeoffActions.air,
+      task = {
+        id = "ComboTask",
+        params = {
+          tasks = {}
+        }
+      }
+    }
+  end
+  -- here we ammend the first point to allow for spawns from airbases if it isn't an airspawn
+  if Airbase.getByName(points[1].place) then
+    if points[1].type ~= "Turning Point" and points[1].action ~= "Turning Point" then
+      local ab = Airbase.getByName(points[1].place)
+      local abId = Airbase.getID(ab)
+      local abCat = Airbase.getDesc(ab).category
+      if abCat == 0 then -- Airbase.Category.AIRDROME
+        builtPoints[1].airdromeId = abId
+      elseif abCat == 2 then -- Airbase.Category.HELIPAD
+        builtPoints[1].linkUnit = abId
+        builtPoints[1].helipadId = abId -- why its named helipad i dont know
+      end
+    end
+  end
+  return builtPoints
+end
+
+local createPlaneGroupUnitsTemplate = function(unitListTemplate)
+    local units = {}
+    for i, unitTemplate in pairs(unitListTemplate) do
+      local pointVec3
+      if type(unitListTemplate.place) == "string" then
+        if Airbase.getByName(unitListTemplate.place) then
+          pointVec3 = Airbase.getByName(unitListTemplate.place):getPoint()
+          env.info("ab point type")
+        elseif trigger.misc.getZone(unitListTemplate.place) then
+          pointVec3 = trigger.misc.getZone(unitListTemplate.place).point
+          env.info("zone point type")
+        end
+      elseif type(unitListTemplate.place) == "table" then
+        pointVec3 = coord.LLtoLO(unitListTemplate.place.lat, unitListTemplate.place.lon)
+      end
+      local fuel = Unit.getDescByName(unitListTemplate.type).fuelMassMax -- needed incase no payload table is applied
+      if type(unitTemplate) == "table" then
+        units[i] = {
+          name = unitTemplate.unitName, -- or unitTemplate.name.."-"..i
+          type = unitListTemplate.type,
+          x = pointVec3.x,
+          y = pointVec3.z,
+          alt = unitListTemplate.alt,
+          alt_type = unitListTemplate.alt_type or "BARO",
+          speed = unitListTemplate.speed,
+          payload = unitTemplate.payload or {
+          ["pylons"] = {},
+          ["fuel"] = fuel,
+          ["flare"] = 0,
+          ["chaff"] = 0,
+          ["gun"] = 0,
+          },
+          parking = unitTemplate.parking or nil,
+          parking_id = unitTemplate.parking_id or nil,
+          callsign = unitTemplate.callsign or nil,
+          skill = unitTemplate.skill or skill.Random,
+          livery_id = unitTemplate.livery_id or nil,
+        }
+      end
+    end
+    return units
+  end
+
+local createPlaneGroupTemplate = function(planeGroupTemplate)
+  local groupTable = {
+    name = planeGroupTemplate.groupName,
+    task = planeGroupTemplate.task,
+    route = {
+      points = buildAirplanePoints(planeGroupTemplate.points)
+    }
+  }
+  groupTable.units = createPlaneGroupUnitsTemplate(planeGroupTemplate.units)
+  if planeGroupTemplate.group_id ~= nil then
+    groupTable['groupId'] = planeGroupTemplate.group_id
+  end
+  if planeGroupTemplate.hidden ~= nil then
+    groupTable['hidden'] = planeGroupTemplate.hidden
+  end
+  if planeGroupTemplate.late_activation ~= nil then
+    groupTable['lateActivation'] = planeGroupTemplate.late_activation
+  end
+  if planeGroupTemplate.start_time ~= nil and planeGroupTemplate.start_time > 0 then
+    groupTable['start_time'] = planeGroupTemplate.start_time
+  end
+  if planeGroupTemplate.visible ~= nil then
+    groupTable['visible'] = planeGroupTemplate.visible
+  end
+  return groupTable
+end
 
 local createGroundUnitsTemplate = function(unitListTemplate)
   local units = {}
@@ -109,9 +254,12 @@ GRPC.methods.addGroup = function(params)
   if params.country_id == 0 or params.country_id == 15 then
     return GRPC.errorInvalidArgument("invalid country code")
   end
-
-  local template = createGroundGroupTemplate(params.template.groundTemplate)
-
+  local template
+  if params.template.type == "Airplane" then
+    template = createPlaneGroupTemplate(params.template.groupTemplate)
+  elseif params.template.type == "Ground" then
+    template = createGroundGroupTemplate(params.template.groundTemplate) -- this should maybe hold the type o
+  end
   coalition.addGroup(params.country - 1, params.groupCategory, template) -- Decrement for non zero-indexed gRPC enum
 
   return GRPC.success({group = GRPC.exporters.group(Group.getByName(template.name))})

--- a/lua/methods/coalitions.lua
+++ b/lua/methods/coalitions.lua
@@ -258,7 +258,7 @@ GRPC.methods.addGroup = function(params)
   if params.template.type == "Airplane" then
     template = createPlaneGroupTemplate(params.template.groupTemplate)
   elseif params.template.type == "Ground" then
-    template = createGroundGroupTemplate(params.template.groundTemplate) -- this should maybe hold the type o
+    template = createGroundGroupTemplate(params.template.groundTemplate)
   end
   coalition.addGroup(params.country - 1, params.groupCategory, template) -- Decrement for non zero-indexed gRPC enum
 


### PR DESCRIPTION
Initial implementation of spawning an airplane group from an airbase, zone, or lat lon coordinate with any number of points. When spawning from an airbase you have the option to spawn hot, cold, runway and in air.
Individual unit payloads are yet to be implemented as are taskings for each point in the route. These can be complex tasks to get done properly, so need to think about how it should be done easily for the end user.

added createPlaneGroupTemplate
returns a table required to spawn an airplane group

added createPlaneGroupUnitsTemplate
return a table of units needed to spawn an airplane
prepares units to spawn from an airbase, zone, or lat lon
if spawned from an airbae options are hot, cold, air, or runway

added buildAirplanePoints
return a table of built points for airplane groups
points are based around vec3's that can be from zones, airbases and lat lon

**notes:**
- when spawning an airplane from an airbase that is a ship it is required to use the unit name as the place
- the place within units is the inital spawning place of the units
- changed the addGroup method to include being able to pick a differnt tempalte based on params.template.type
- types could be "Ground" "Helicopter, "Airplane", "Sea" if implemented that way