### PR TITLE
Add logging around config file writing

### DIFF
--- a/lua/grpc-mission.lua
+++ b/lua/grpc-mission.lua
@@ -15,18 +15,19 @@ end
 -- Let DCS know where to find the DLLs
 package.cpath = package.cpath .. GRPC.dllPath .. [[?.dll;]]
 
+env.info("[GRPC] Writing " .. lfs.writedir() .. [[Data\dcs-grpc.lua]] )
 -- Make settings available to gRPC hook
-local file, err = io.open(lfs.writedir() .. [[Data\dcs-grpc.lua]], "w")
-if err then
-	env.error("[GRPC] Error writing config")
-else
-	file:write(
+local f, err = io.open(lfs.writedir() .. [[Data\dcs-grpc.lua]], "w")
+if f then
+  file:write(
     "luaPath = [[" .. GRPC.luaPath .. "]]\n"
     .. "dllPath = [[" .. GRPC.dllPath .. "]]\n"
     .. "throughputLimit = [[" .. GRPC.throughputLimit .. "]]\n"
   )
-	file:flush()
-	file:close()
+  file:flush()
+  file:close()
+else
+  env.error("[GRPC] Error writing config: " .. err)
 end
 
 -- Load DLL before `require` gets sanitized.

--- a/lua/grpc-mission.lua
+++ b/lua/grpc-mission.lua
@@ -17,8 +17,8 @@ package.cpath = package.cpath .. GRPC.dllPath .. [[?.dll;]]
 
 env.info("[GRPC] Writing " .. lfs.writedir() .. [[Data\dcs-grpc.lua]] )
 -- Make settings available to gRPC hook
-local f, err = io.open(lfs.writedir() .. [[Data\dcs-grpc.lua]], "w")
-if f then
+local file, err = io.open(lfs.writedir() .. [[Data\dcs-grpc.lua]], "w")
+if file then
   file:write(
     "luaPath = [[" .. GRPC.luaPath .. "]]\n"
     .. "dllPath = [[" .. GRPC.dllPath .. "]]\n"


### PR DESCRIPTION
Add logging regarding the writing of the `Data\dcs-grpc.lua`
file and change the check to make sure that `f` is not nill rather
than there is a definite error as this appears to be the safer, more
idiomatic, way of doing it.

This should help a bit with debugging issues some users appear to
be having.