### PR TITLE
add logs for host, ip and config

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ pub fn start(_: &Lua, config: Config) -> LuaResult<()> {
 
     init(&config);
 
+    log::debug!("Config: {:#?}", config);
     log::info!("Starting ...");
 
     let mut server =

--- a/src/server.rs
+++ b/src/server.rs
@@ -143,7 +143,7 @@ async fn try_run(
     shutdown_signal: ShutdownHandle,
     after_shutdown: &mut Receiver<()>,
 ) -> Result<(), transport::Error> {
-    log::info!("Staring gRPC Server ...");
+    log::info!("Staring gRPC Server (on {}) ...", state.addr);
 
     let ServerState {
         addr,


### PR DESCRIPTION
Add IP and port (fixes #81):

```diff
- dcs_grpc::server: Staring gRPC Server ...
+ dcs_grpc::server: Staring gRPC Server (on 127.0.0.1:50051) ...
```

Add whole config (if `debug = true`):

```
2021-12-23 09:44:00.285 DEBUG   dcs_grpc: Config: Config {
    write_dir: "m:\\Saved Games\\DCS.openbeta\\",
    dll_path: "M:\\Development\\DCS-gRPC\\rust-server\\target\\debug\\",
    host: "127.0.0.1",
    port: 50051,
    debug: true,
    eval_enabled: true,
}
```