### PR TITLE
add support for config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,21 +83,36 @@ GRPC.throughputLimit = 600
 GRPC.autostart = false
 ```
 
-Settings can either be set above `GRPC.load()` inside of a mission, or globally inside of the `MissionScripting.lua`, e.g.:
+Settings can either be set:
+- above `GRPC.load()` inside of a mission,
+  ```lua
+  GRPC.debug = true
+  GRPC.autostart = true
+  GRPC.load()
+  ```
 
-```diff
-  --Initialization script for the Mission lua Environment (SSE)
+- inside a `Saved Games\DCS\Config\dcs-grpc.lua` file (useful if run multiple servers in parallel), or
 
-  dofile('Scripts/ScriptingSystem.lua')
-+
-+ GRPC = {
-+   throughputLimit = 200,
-+   autostart = true
-+ }
-+ dofile(lfs.writedir()..[[Scripts\DCS-gRPC\grpc-mission.lua]])
+  `Saved Games\DCS\Config\dcs-grpc.lua`:
+  ```lua
+  GRPC.debug = true
+  GRPC.autostart = true
+  ```
 
-  ...
-```
+- globally inside of the `MissionScripting.lua`
+  ```diff
+    --Initialization script for the Mission lua Environment (SSE)
+
+    dofile('Scripts/ScriptingSystem.lua')
+  +
+  + GRPC = {
+  +   throughputLimit = 200,
+  +   autostart = true
+  + }
+  + dofile(lfs.writedir()..[[Scripts\DCS-gRPC\grpc-mission.lua]])
+
+    ...
+  ```
 
 ### Confirmation
 

--- a/lua/grpc-mission.lua
+++ b/lua/grpc-mission.lua
@@ -4,11 +4,15 @@ end
 
 -- load settings from `Saved Games/DCS/Config/dcs-grpc.lua`
 do
+	env.error("[GRPC] Checking optional config at `Config/dcs-grpc.lua` ...")
   local file, err = io.open(lfs.writedir() .. [[Config\dcs-grpc.lua]], "r")
-  if not err then
-    local env = setmetatable({}, {__index = GRPC})
-    local f = setfenv(assert(loadstring(file:read("*all"))), env)
+  if file then
+    local e = setmetatable({}, {__index = GRPC})
+    local f = setfenv(assert(loadstring(file:read("*all"))), e)
     f()
+    env.info("[GRPC] Optional config at `Config/dcs-grpc.lua` successfully read")
+  else
+	  env.info("[GRPC] Optional config at `Config/dcs-grpc.lua` not found")
   end
 end
 

--- a/lua/grpc-mission.lua
+++ b/lua/grpc-mission.lua
@@ -1,7 +1,18 @@
--- Set default settings.
 if not _G.GRPC then
   _G.GRPC = {}
 end
+
+-- load settings from `Saved Games/DCS/Config/dcs-grpc.lua`
+do
+  local file, err = io.open(lfs.writedir() .. [[Config\dcs-grpc.lua]], "r")
+  if not err then
+    local env = setmetatable({}, {__index = GRPC})
+    local f = setfenv(assert(loadstring(file:read("*all"))), env)
+    f()
+  end
+end
+
+-- Set default settings.
 if not GRPC.luaPath then
   GRPC.luaPath = lfs.writedir() .. [[Scripts\DCS-gRPC\]]
 end

--- a/lua/grpc-mission.lua
+++ b/lua/grpc-mission.lua
@@ -12,7 +12,7 @@ do
     f()
     env.info("[GRPC] Optional config at `Config/dcs-grpc.lua` successfully read")
   else
-	  env.info("[GRPC] Optional config at `Config/dcs-grpc.lua` not found")
+	  env.info("[GRPC] Optional config at `Config/dcs-grpc.lua` not found (" .. tostring(err) .. ")")
   end
 end
 


### PR DESCRIPTION
Add support to configure the gRPC server via a config file. This should help users that run multiple servers in parallel and thus need different settings per instance.

See [README](https://github.com/DCS-gRPC/rust-server/blob/config-file/README.md#settings) for instructions of how the config file works.