### PR TITLE
Allow forks to CI check before PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: ["*"]
   pull_request:
     branches: [main]
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,11 @@ return Group.getByName('Aerial-1'):getName()
 
 The REPL is also available in the release and can be run by running `Tools/DCS-gRPC/repl.exe`
 
+### Contributions
+
+This repository is powered by GitHub Actions for the Continuous Integration (CI) services. The same CI checks would be triggered and executed as you push code to your forked repository, and providing early feedback before a maintainer executes a manual execution on the pull request.
+
+
 ### Troublshooting
 
 #### Linker Error 1104


### PR DESCRIPTION
Let's improve the Quality of Life for third party contributors by allowing them to anticipate whether or not their PR would satisfy the CI-gates.

This would also free up the maintainers from anticipating issues, and allow the linting checks to be automated.

![image](https://user-images.githubusercontent.com/178498/148360659-92e4200c-aa76-455e-a092-b4522a31835e.png)

This would not generate a security issue as these builds are pinned to the forked repository. It still requires consent from the maintainers to execute the `pull_request` trigger from third parties. (This PR being a self-verification :) )