### PR TITLE
use config file as only source for settings

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,6 +1,7 @@
 std = "lua51"
 globals = {
   "GRPC",
+  "grpc",
 }
 read_globals = {
   "AI",
@@ -10,7 +11,6 @@ read_globals = {
   "DCS",
   "env",
   "Group",
-  "grpc",
   "land",
   "lfs",
   "log",

--- a/README.md
+++ b/README.md
@@ -173,6 +173,22 @@ For development, update the previously added line in `DCS World\Scripts\MissionS
 + dofile(GRPC.luaPath .. [[grpc-mission.lua]])
 ```
 
+In addition, you will need to replace the hook script at `Scripts\Hooks\DCS-gRPC.lua` to load up your current in development hook script:
+
+```lua
+function init()
+    log.write("[GRPC-Hook-DEV]", log.INFO, "Initializing ...")
+    dofile(GRPC.luaPath .. [[grpc-hook.lua]])
+    log.write("[GRPC-Hook-DEV]", log.INFO, "Initialized ...")
+end
+
+
+local ok, err = pcall(init)
+if not ok then
+  log.write("[GRPC-Hook-DEV]", log.ERROR, "Failed to Initialize: "..tostring(err))
+end
+```
+
 ### Debugging
 
 - Search for `[GRPC]` in the DCS logs

--- a/README.md
+++ b/README.md
@@ -51,68 +51,42 @@ Add the following code to your mission. This will start the DCS-gRPC server. You
 trigger in your .miz file or you can add this code to an existing lua file that your mission may be running.
 
 ```lua
--- Optional: Change settings if desired, e.g.:
-GRPC.debug = true
-
--- Required: Load the gRPC server into the mission
+-- Load the gRPC server into the mission
 GRPC.load()
 ```
 
 ### Settings
 
-The behaviour of the gRPC server can be fine-tuned using various settings that can be set on the `GRPC` global (before the `grpc.lua` is executed). The available settings and their defaults are:
+The behaviour of the gRPC server can be fine-tuned using various settings that can be set inside of `Saved Games\DCS\Config\dcs-grpc.lua` (must be created if it doesn't exist). The available settings and their defaults are:
 
 ```lua
 -- Whether the `Eval` method is enabled or not.
-GRPC.evalEnabled = false
+evalEnabled = false
 
 -- The host the gRPC listens on (use "0.0.0.0" to listen on all IP addresses of the host).
-GRPC.host = '127.0.0.1'
+host = '127.0.0.1'
 
 -- The port to listen on.
-GRPC.port = 50051
+port = 50051
 
 -- Whether debug logging is enabled or not.
-GRPC.debug = false
+debug = false
 
 -- Limit of calls per second that are executed inside of the mission scripting environment.
-GRPC.throughputLimit = 600
+throughputLimit = 600
 
 -- Whether the gRPC server should be automatically started for each mission on the DCS instance
 -- When `true`, it is not necessary to run `GRPC.load()` inside of a mission anymore.
-GRPC.autostart = false
+autostart = false
 ```
 
-Settings can either be set:
-- above `GRPC.load()` inside of a mission,
-  ```lua
-  GRPC.debug = true
-  GRPC.autostart = true
-  GRPC.load()
-  ```
+The settings `evalEnabled` and `debug` can also be set on the `GRPC` global before `GRPC.load()` is called (unless `autostart` is `true`):
 
-- inside a `Saved Games\DCS\Config\dcs-grpc.lua` file (useful if run multiple servers in parallel), or
-
-  `Saved Games\DCS\Config\dcs-grpc.lua`:
-  ```lua
-  GRPC.debug = true
-  GRPC.autostart = true
-  ```
-
-- globally inside of the `MissionScripting.lua`
-  ```diff
-    --Initialization script for the Mission lua Environment (SSE)
-
-    dofile('Scripts/ScriptingSystem.lua')
-  +
-  + GRPC = {
-  +   throughputLimit = 200,
-  +   autostart = true
-  + }
-  + dofile(lfs.writedir()..[[Scripts\DCS-gRPC\grpc-mission.lua]])
-
-    ...
-  ```
+```lua
+GRPC.evalEnabled = true
+GRPC.debug = true
+GRPC.load()
+```
 
 ### Confirmation
 
@@ -160,34 +134,21 @@ cargo build --features hot-reload
 copy target/debug/dcs_grpc.dll target/debug/dcs_grpc_hot_reload.dll
 ```
 
-### Prepare Mission
+### Prepare DCS
 
-For development, update the previously added line in `DCS World\Scripts\MissionScripting.lua` to point to your checked out repository of the gRPC server:
+For development:
 
-```diff
-- dofile(lfs.writedir()..[[Scripts\DCS-gRPC\grpc-mission.lua]])
-+ GRPC = {
-+ 	dllPath = [[C:\Development\DCS-gRPC\rust-server\target\debug\]],
-+ 	luaPath = [[C:\Development\DCS-gRPC\rust-server\lua\DCS-gRPC]]
-+ }
-+ dofile(GRPC.luaPath .. [[grpc-mission.lua]])
-```
-
-In addition, you will need to replace the hook script at `Scripts\Hooks\DCS-gRPC.lua` to load up your current in development hook script:
-
-```lua
-function init()
-    log.write("[GRPC-Hook-DEV]", log.INFO, "Initializing ...")
-    dofile(GRPC.luaPath .. [[grpc-hook.lua]])
-    log.write("[GRPC-Hook-DEV]", log.INFO, "Initialized ...")
-end
-
-
-local ok, err = pcall(init)
-if not ok then
-  log.write("[GRPC-Hook-DEV]", log.ERROR, "Failed to Initialize: "..tostring(err))
-end
-```
+- update your `MissionScripting.lua` to load `grpc-mission.lua` from your local clone, e.g.:
+  ```diff
+  - dofile(lfs.writedir()..[[Scripts\DCS-gRPC\grpc-mission.lua]])
+  + dofile([[C:\Development\DCS-gRPC\rust-server\lua\DCS-gRPC\grpc-mission.lua]])
+  ```
+- add custom `dllPath` and `luaPath` settings to your `Saved Games\DCS\Config\dcs-grpc.lua`:
+  ```lua
+  dllPath = [[C:\Development\DCS-gRPC\rust-server\target\debug\]]
+  luaPath = [[C:\Development\DCS-gRPC\rust-server\lua\DCS-gRPC\]]
+  ```
+- copy the hook script from `lua\Hooks\DCS-gRPC.lua` to `Scripts\Hooks\DCS-gRPC.lua`
 
 ### Debugging
 

--- a/lua/DCS-gRPC/grpc-hook.lua
+++ b/lua/DCS-gRPC/grpc-hook.lua
@@ -1,0 +1,86 @@
+-- note: the hook's load will only fire after the mission loaded.
+local function load()
+  log.write("[GRPC-Hook]", log.INFO, "mission loaded, setting up gRPC listener ...")
+
+  -- Let DCS know where to find the DLLs
+  if not string.find(package.cpath, GRPC.dllPath) then
+    package.cpath = package.cpath .. GRPC.dllPath .. [[?.dll;]]
+  end
+
+  local ok, grpc = pcall(require, "dcs_grpc_hot_reload")
+  if ok then
+    log.write("[GRPC-Hook]", log.INFO, "loaded hot reload version")
+  else
+    grpc = require("dcs_grpc")
+  end
+
+  _G.grpc = grpc
+  assert(pcall(assert(loadfile(GRPC.luaPath .. [[grpc.lua]]))))
+
+  log.write("[GRPC-Hook]", log.INFO, "gRPC listener set up.")
+end
+
+local handler = {}
+
+function handler.onMissionLoadEnd()
+  local ok, err = pcall(load)
+  if not ok then
+    log.write("[GRPC-Hook]", log.ERROR, "Failed to set up gRPC listener: "..tostring(err))
+  end
+end
+
+function handler.onSimulationFrame()
+  if GRPC.onSimulationFrame then
+    GRPC.onSimulationFrame()
+  end
+end
+
+function handler.onSimulationStop()
+  log.write("[GRPC-Hook]", log.INFO, "simulation stopped, shutting down gRPC listener ...")
+
+  GRPC.stop()
+  grpc = nil
+end
+
+function handler.onPlayerTrySendChat(playerID, msg)
+  -- note: currently `all` (third parameter) will always `=true` regardless if the target is to the coalition/team
+  --        or to everybody. When ED fixes this, implementation should determine the dcs.common.v0.Coalition
+
+  grpc.event({
+    time = DCS.getModelTime(),
+    event = {
+      type = "playerSendChat",
+      playerId = playerID,
+      message = msg
+    },
+  })
+
+  return msg
+end
+
+function handler.onPlayerTryConnect(addr, name, ucid, id)
+  grpc.event({
+    time = DCS.getModelTime(),
+    event = {
+      type = "connect",
+      addr = addr,
+      name = name,
+      ucid = ucid,
+      id = id,
+    },
+  })
+  -- not returning `true` here to allow other scripts to handle this hook
+end
+
+function handler.onPlayerDisconnect(id, reason)
+  grpc.event({
+    time = DCS.getModelTime(),
+    event = {
+      type = "disconnect",
+      id = id,
+      reason = reason + 1, -- Increment for non zero-indexed gRPC enum
+    },
+  })
+end
+
+DCS.setUserCallbacks(handler)

--- a/lua/DCS-gRPC/grpc-mission.lua
+++ b/lua/DCS-gRPC/grpc-mission.lua
@@ -4,15 +4,15 @@ end
 
 -- load settings from `Saved Games/DCS/Config/dcs-grpc.lua`
 do
-	env.error("[GRPC] Checking optional config at `Config/dcs-grpc.lua` ...")
+  env.info("[GRPC] Checking optional config at `Config/dcs-grpc.lua` ...")
   local file, err = io.open(lfs.writedir() .. [[Config\dcs-grpc.lua]], "r")
   if file then
     local f = assert(loadstring(file:read("*all")))
     setfenv(f, GRPC)
     f()
-    env.info("[GRPC] Optional config at `Config/dcs-grpc.lua` successfully read")
+    env.info("[GRPC] `Config/dcs-grpc.lua` successfully read")
   else
-	  env.info("[GRPC] Optional config at `Config/dcs-grpc.lua` not found (" .. tostring(err) .. ")")
+    env.info("[GRPC] `Config/dcs-grpc.lua` not found (" .. tostring(err) .. ")")
   end
 end
 
@@ -28,21 +28,8 @@ if GRPC.throughputLimit == nil or GRPC.throughputLimit == 0 or not type(GRPC.thr
 end
 
 -- Let DCS know where to find the DLLs
-package.cpath = package.cpath .. GRPC.dllPath .. [[?.dll;]]
-
-env.info("[GRPC] Writing " .. lfs.writedir() .. [[Data\dcs-grpc.lua]] )
--- Make settings available to gRPC hook
-local file, err = io.open(lfs.writedir() .. [[Data\dcs-grpc.lua]], "w")
-if file then
-  file:write(
-    "luaPath = [[" .. GRPC.luaPath .. "]]\n"
-    .. "dllPath = [[" .. GRPC.dllPath .. "]]\n"
-    .. "throughputLimit = [[" .. GRPC.throughputLimit .. "]]\n"
-  )
-  file:flush()
-  file:close()
-else
-  env.error("[GRPC] Error writing config: " .. err)
+if not string.find(package.cpath, GRPC.dllPath) then
+  package.cpath = package.cpath .. GRPC.dllPath .. [[?.dll;]]
 end
 
 -- Load DLL before `require` gets sanitized.

--- a/lua/DCS-gRPC/grpc.lua
+++ b/lua/DCS-gRPC/grpc.lua
@@ -1,4 +1,4 @@
-local isMissionEnv = _G.DCS == nil
+local isMissionEnv = DCS == nil
 
 if isMissionEnv then
   env.info("[GRPC] mission loading ...")

--- a/lua/Hooks/DCS-gRPC.lua
+++ b/lua/Hooks/DCS-gRPC.lua
@@ -1,5 +1,5 @@
-package.cpath = package.cpath..lfs.writedir()..[[Mods\tech\DCS-gRPC\?.dll;]]
-
+-- note: the hook's load will only fire after the mission loaded. Therefore, all setup
+-- will be passed into the config file (via the file system)
 local function load()
   log.write("[GRPC-Hook]", log.INFO, "mission loaded, setting up gRPC listener ...")
 
@@ -18,7 +18,7 @@ local function load()
   end
 
   -- Let DCS know where to find the DLLs
-  if not string.find(package.cpath, "DCS-gRPC") then
+  if not string.find(package.cpath, GRPC.dllPath) then
     package.cpath = package.cpath .. GRPC.dllPath .. [[?.dll;]]
   end
 


### PR DESCRIPTION
Before this commit it was possible to set settings either:
1) before the `dofile` inside of `MissionScription.lua`,
2) before `GRPC.load()` inside of a mission, and
3) inside of the config file at `Saved Games\DCS\Config\dcs-grpc.lua`.

This commit
a) removes (1),
b) documents the limitations of (2),
c) splits `Hooks/DCS-gRPC.lua` into two parts, and
c) removes all unnecessary `_G.` prefixes on globals (in Lua code; just
   a cleanup as a side-effect of the refactoring).

Reducing the amount of locations that settings can be configured (a)
simplifies the code and reduces the amount things that need to be
tested. More importantly, it removes the need of the temporary
`Data/dcs-grpc.lua` file (which is removed).

With (c) it is now easier to develop the hooks part of DCS-gRPC as it
allows a setup where the actual hook logic (now in
`lua\DCS-gRPC\grpc-hook.lua`) can be loaded from a local repository.
`lua\Hooks\DCS-gRPC.lua` is still there, but it should rarely change
during development as it is only responsible for loading the config and
then executing `lua\DCS-gRPC\grpc-hook.lua` (where the actual hook logic
is implemented).