### PR TITLE
GetPlayerInfo implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Generated scaffolding for the `net.*` scope into `NetService`
 - `SendChat` API
 - `SendChatTo` API
+- `GetPlayerInfo` API
 
 ### Changed
 - Stream `PlayerSendChatEvent` to the `MissionService.StreamEvents` for clients to observe the chat as part of the event stream

--- a/lua/DCS-gRPC/methods/net.lua
+++ b/lua/DCS-gRPC/methods/net.lua
@@ -20,3 +20,23 @@ GRPC.methods.sendChat = function(params)
     net.send_chat(params.message, toAll)
     return GRPC.success(nil)
 end
+
+GRPC.methods.getPlayerInfo = function(params)
+    local playerInfo = net.get_player_info(params.id);
+
+    if playerInfo == nil then
+        return GRPC.errorNotFound("requested player could not be found")
+    end
+
+    local normalizedResult = {
+        ["id"] = playerInfo.id,
+        ["name"] = playerInfo.name,
+        ["coalition"] = playerInfo.side + 1, -- common.Coalition enum offset
+        ["slot"] = playerInfo.slot,
+        ["ping"] = playerInfo.ping,
+        ["remoteAddress"] = playerInfo.ipaddr,
+        ["ucid"] = playerInfo.ucid,
+        ["locale"] = playerInfo.lang
+    }
+    return GRPC.success(normalizedResult)
+end

--- a/protos/dcs/net/v0/net.proto
+++ b/protos/dcs/net/v0/net.proto
@@ -8,6 +8,9 @@ service NetService {
 
   // https://wiki.hoggitworld.com/view/DCS_func_send_chat
   rpc SendChat(SendChatRequest) returns (SendChatResponse) {}
+
+  // https://wiki.hoggitworld.com/view/DCS_func_get_player_info
+  rpc GetPlayerInfo(GetPlayerInfoRequest) returns (GetPlayerInfoResponse) {}
 }
 
 message SendChatToRequest {
@@ -27,3 +30,27 @@ message SendChatRequest {
 }
 
 message SendChatResponse {}
+
+message GetPlayerInfoRequest {
+  // the player id
+  uint32 id = 1;
+}
+
+message GetPlayerInfoResponse {
+  // the player id
+  uint32 id = 1;
+  // player's online name
+  string name = 2;
+  // coalition which player is slotted in
+  dcs.common.v0.Coalition coalition = 3;
+  // the slot identifier
+  string slot = 4;
+  // the ping of the player
+  uint32 ping = 5;
+  // the connection ip address and port the client has established with the server
+  string remoteAddress = 6;
+  // the unique identifier for the player
+  string ucid = 7;
+  // abbreviated language (locale) e.g. "en"
+  string locale = 8;
+}

--- a/src/rpc/net.rs
+++ b/src/rpc/net.rs
@@ -20,4 +20,13 @@ impl NetService for MissionRpc {
         self.notification("sendChat", request).await?;
         Ok(Response::new(net::v0::SendChatResponse {}))
     }
+
+    // getPlayerInfo
+    async fn get_player_info(
+        &self,
+        request: Request<net::v0::GetPlayerInfoRequest>,
+    ) -> Result<Response<net::v0::GetPlayerInfoResponse>, Status> {
+        let res: net::v0::GetPlayerInfoResponse = self.request("getPlayerInfo", request).await?;
+        Ok(Response::new(res))
+    }
 }


### PR DESCRIPTION
Getting the player info based on the player id.
- locale is an undocumented attribute / would serve well for multilingual cases
- ipAddr is actually `{address}:{port}`

# Sample Output

## Player occupies slot
```
grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs/dcs.proto -d '{\"id\": 2}' 127.0.0.1:50051 dcs.net.v0.NetService/GetPlayerInfo
{
  "id": 2,
  "name": "[OCG] \"Gabs\"",
  "coalition": "COALITION_BLUE",
  "slot": "815",
  "remoteAddress": "127.0.0.1:49252",
  "ucid": "REDACTED",
  "locale": "en"
}
```

## Player is in spectators
```
grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs/dcs.proto -d '{\"id\": 2}' 127.0.0.1:50051 dcs.net.v0.NetService/GetPlayerInfo 
{
  "id": 2,
  "name": "[OCG] \"Gabs\"",
  "coalition": "COALITION_NEUTRAL",
  "remoteAddress": "127.0.0.1:49300",
  "ucid": "REDACTED",
  "locale": "en"
}
```

## Queried player is unknown
```
grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs/dcs.proto -d '{\"id\": 20}' 127.0.0.1:50051 dcs.net.v0.NetService/GetPlayerInfo
ERROR:
  Code: NotFound
  Message: requested player could not be found

```