### PR TITLE
GetPlayerList implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Generated scaffolding for the `net.*` scope into `NetService`
+- `GetPlayerList` API
 - `SendChat` API
 - `SendChatTo` API
 

--- a/lua/DCS-gRPC/methods/net.lua
+++ b/lua/DCS-gRPC/methods/net.lua
@@ -3,6 +3,11 @@
 -- https://wiki.hoggitworld.com/view/DCS_singleton_net
 --
 
+GRPC.methods.getPlayerList = function()
+    local playerList = net.get_player_list()
+    return GRPC.success({ids = playerList})
+end
+
 GRPC.methods.sendChatTo = function(params)
     -- note: it was explicitly decided not to place "from player id" parameter
     --       due to the magnitude of a social attack vector.

--- a/protos/dcs/net/v0/net.proto
+++ b/protos/dcs/net/v0/net.proto
@@ -3,11 +3,21 @@ package dcs.net.v0;
 import "dcs/common/v0/common.proto";
 
 service NetService {
+  // https://wiki.hoggitworld.com/view/DCS_func_get_player_list
+  rpc GetPlayerList(GetPlayerListRequest) returns (GetPlayerListResponse) {}
+
   // https://wiki.hoggitworld.com/view/DCS_func_send_chat_to
   rpc SendChatTo(SendChatToRequest) returns (SendChatToResponse) {}
 
   // https://wiki.hoggitworld.com/view/DCS_func_send_chat
   rpc SendChat(SendChatRequest) returns (SendChatResponse) {}
+}
+
+message GetPlayerListRequest {}
+
+message GetPlayerListResponse {
+  // the player ids connected to the mission/server
+  repeated uint32 ids = 1;
 }
 
 message SendChatToRequest {

--- a/src/rpc/net.rs
+++ b/src/rpc/net.rs
@@ -5,6 +5,14 @@ use tonic::{Request, Response, Status};
 
 #[tonic::async_trait]
 impl NetService for MissionRpc {
+    async fn get_player_list(
+        &self,
+        request: Request<net::v0::GetPlayerListRequest>,
+    ) -> Result<Response<net::v0::GetPlayerListResponse>, Status> {
+        let res: net::v0::GetPlayerListResponse = self.request("getPlayerList", request).await?;
+        Ok(Response::new(res))
+    }
+
     async fn send_chat_to(
         &self,
         request: Request<net::v0::SendChatToRequest>,


### PR DESCRIPTION
Returns a list of player identifiers connected to the server

```
grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs/dcs.proto -d '{}' 127.0.0.1:50051 dcs.net.v0.NetService/GetPlayerList         
{
  "ids": [
    1,
    2
  ]
}
```