### PR TITLE
CI: Cache build improves build time from 5mins to 1m30s-2m10s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
I got annoyed by the build times on the CI. 

So here is a fix.

![image](https://user-images.githubusercontent.com/178498/149330676-c4e37724-18cc-495f-b795-275891974c94.png)
