### PR TITLE
GetPlayers returns all connected player attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Generated scaffolding for the `net.*` scope into `NetService`
 - `SendChat` API
 - `SendChatTo` API
+- `GetPlayers` API
 
 ### Changed
 - Stream `PlayerSendChatEvent` to the `MissionService.StreamEvents` for clients to observe the chat as part of the event stream

--- a/lua/DCS-gRPC/methods/net.lua
+++ b/lua/DCS-gRPC/methods/net.lua
@@ -20,3 +20,24 @@ GRPC.methods.sendChat = function(params)
     net.send_chat(params.message, toAll)
     return GRPC.success(nil)
 end
+
+GRPC.methods.getPlayers = function()
+    local players = {};
+
+    for _,v in pairs(net.get_player_list()) do
+        local playerInfo = net.get_player_info(v);
+
+        table.insert(players, {
+            id = playerInfo.id,
+            name = playerInfo.name,
+            coalition = playerInfo.side + 1, -- common.Coalition enum offset
+            slot = playerInfo.slot,
+            ping = playerInfo.ping,
+            remoteAddress = playerInfo.ipaddr,
+            ucid = playerInfo.ucid,
+            locale = playerInfo.lang
+        })
+    end
+
+    return GRPC.success({players = players})
+end

--- a/protos/dcs/net/v0/net.proto
+++ b/protos/dcs/net/v0/net.proto
@@ -8,6 +8,10 @@ service NetService {
 
   // https://wiki.hoggitworld.com/view/DCS_func_send_chat
   rpc SendChat(SendChatRequest) returns (SendChatResponse) {}
+
+  // returns a list of all connected players.
+  // https://wiki.hoggitworld.com/view/DCS_func_get_player_info
+  rpc GetPlayers(GetPlayersRequest) returns (GetPlayersResponse) {}
 }
 
 message SendChatToRequest {
@@ -27,3 +31,31 @@ message SendChatRequest {
 }
 
 message SendChatResponse {}
+
+message GetPlayersRequest {}
+
+message GetPlayersResponse {
+  message GetPlayerInfo {
+    // the player id
+    uint32 id = 1;
+    // player's online name
+    string name = 2;
+    // coalition which player is slotted in
+    dcs.common.v0.Coalition coalition = 3;
+    // the slot identifier
+    string slot = 4;
+    // the ping of the player
+    uint32 ping = 5;
+    // the connection ip address and port the client has established with the server
+    string remoteAddress = 6;
+    // the unique identifier for the player
+    string ucid = 7;
+    // abbreviated language (locale) e.g. "en"
+    string locale = 8;
+  }
+
+  // list of all the players connected to the server
+  repeated GetPlayerInfo players = 1;
+}
+
+

--- a/src/rpc/net.rs
+++ b/src/rpc/net.rs
@@ -20,4 +20,12 @@ impl NetService for MissionRpc {
         self.notification("sendChat", request).await?;
         Ok(Response::new(net::v0::SendChatResponse {}))
     }
+
+    async fn get_players(
+        &self,
+        request: Request<net::v0::GetPlayersRequest>,
+    ) -> Result<Response<net::v0::GetPlayersResponse>, Status> {
+        let res: net::v0::GetPlayersResponse = self.request("getPlayers", request).await?;
+        Ok(Response::new(res))
+    }
 }


### PR DESCRIPTION
Getting the player info based on the players connected to the server. This is a
combined loop of `net.get_player_list` and `net.get_player_info`.

Notes about the player information which differs from official documentation.
- locale is an undocumented attribute / would serve well for multilingual cases
- ipAddr is actually `{address}:{port}`

It was decided to perform the compound variation of the API. In theory, it should
work effectively but needs to be verified by densely populated servers.

```
grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs/dcs.proto -d '{}' 127.0.0.1:50051 dcs.net.v0.NetService/GetPlayers
{
  "players": [
    {
      "id": 1,
      "name": "PILOT_842104",
      "coalition": "COALITION_NEUTRAL",
      "remoteAddress": "103.1.212.100:10308",
      "ucid": "REDACTED",
      "locale": "en"
    },
    {
      "id": 2,
      "name": "[OCG] \"Gabs\"",
      "coalition": "COALITION_BLUE",
      "slot": "816",
      "remoteAddress": "127.0.0.1:59982",
      "ucid": "REDACTED",
      "locale": "en"
    }
  ]
}
```