### PR TITLE
Emit when a player changes to a slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `PlayerChangeSlotEvent` emitted when player changes slot
+
 ### Fixed
 - Corrected `proto` files from camel-casing to snake-casing; not a runtime breaking change but some code generators
   may generate different casing by convention, creating a compiler only issue.

--- a/lua/DCS-gRPC/grpc-hook.lua
+++ b/lua/DCS-gRPC/grpc-hook.lua
@@ -83,4 +83,18 @@ function handler.onPlayerDisconnect(id, reason)
   })
 end
 
+function handler.onPlayerChangeSlot(playerId)
+  local playerInfo = net.get_player_info(playerId)
+
+  grpc.event({
+    time = DCS.getModelTime(),
+    event = {
+      type = "playerChangeSlot",
+      playerId = playerId,
+      coalition = playerInfo.side + 1, -- offsetting for grpc COALITION enum
+      slotId = playerInfo.slot
+    },
+  })
+end
+
 DCS.setUserCallbacks(handler)

--- a/protos/dcs/mission/v0/mission.proto
+++ b/protos/dcs/mission/v0/mission.proto
@@ -310,6 +310,16 @@ message StreamEventsResponse {
     // what was typed
     string message = 2;
   }
+
+  // fired when the player changes across to a slot
+  message PlayerChangeSlotEvent {
+    // The player's id in the current server session.
+    uint32 player_id = 1;
+    // The slot's coalition
+    dcs.common.v0.Coalition coalition = 2;
+    // The slot's identifier
+    string slotId = 3;
+  }
   
   /**
    * Fired when a player connected to the server.
@@ -401,6 +411,7 @@ message StreamEventsResponse {
     ConnectEvent connect = 8192;
     DisconnectEvent disconnect = 8193;
     PlayerSendChatEvent player_send_chat = 8194;
+    PlayerChangeSlotEvent player_change_slot = 8195;
   }
 }
 


### PR DESCRIPTION
The DCS Control API should emit a special event to the gRPC
clients that a player has changed a slot.

```
grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs/dcs.proto -d '{}' 127.0.0.1:50051 dcs.mission.v0.MissionService/StreamEvents
{                      
  "time": 26.399,      
  "playerChangeSlot": {
    "playerId": 2,
    "coalition": "COALITION_BLUE",
    "slotId": "817"
  }
}
{
  "time": 33.158,
  "playerChangeSlot": {
    "playerId": 2,
    "coalition": "COALITION_BLUE",
    "slotId": "816"
  }
}
{
  "time": 33.158,
  "playerLeaveUnit": {
    "initiator": {

    }
  }
}

```