### PR TITLE
Deconflict get player units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 - Added `GROUP_CATEGORY_UNSPECIFIED` to `dcs.v0.common.GroupCategory`; breaking change as all indexes have changed.
+- `CoalitionService.GetPlayers` was renamed to `CoalitionService.GetPlayerUnits`; fixes conflict with `NetService.GetPlayers`
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `StreamUnits` can optionally specify the `category` of the units which may be monitored.
 
 ### Fixed
+- `NetService.GetPlayers` overwrote `CoalitionService.GetPlayers` (see Breaking Changes for details)
 - Corrected `proto` files from camel-casing to snake-casing; not a runtime breaking change but some code generators
   may generate different casing by convention, creating a compiler only issue.
   - `net.proto` - `GetPlayerInfo.remote_address`

--- a/lua/DCS-gRPC/methods/coalitions.lua
+++ b/lua/DCS-gRPC/methods/coalitions.lua
@@ -156,7 +156,7 @@ GRPC.methods.getBullseye = function(params)
   })
 end
 
-GRPC.methods.getPlayers = function(params)
+GRPC.methods.getPlayerUnits = function(params)
   local units = coalition.getPlayers(params.coalition)
   local result = {}
   for i, unit in ipairs(units) do

--- a/protos/dcs/coalition/v0/coalition.proto
+++ b/protos/dcs/coalition/v0/coalition.proto
@@ -22,7 +22,7 @@ service CoalitionService {
   rpc GetBullseye(GetBullseyeRequest) returns (GetBullseyeResponse) {}
 
   // https://wiki.hoggitworld.com/view/DCS_func_getPlayers
-  rpc GetPlayers(GetPlayersRequest) returns (GetPlayersResponse) {}
+  rpc GetPlayerUnits(GetPlayerUnitsRequest) returns (GetPlayerUnitsResponse) {}
 }
 
 message AddGroupRequest {
@@ -131,10 +131,10 @@ message GetBullseyeResponse {
   dcs.common.v0.Position position = 1;
 }
 
-message GetPlayersRequest {
+message GetPlayerUnitsRequest {
   dcs.common.v0.Coalition coalition = 1;
 }
 
-message GetPlayersResponse {
+message GetPlayerUnitsResponse {
   repeated dcs.common.v0.Unit units = 1;
 }

--- a/src/rpc/coalition.rs
+++ b/src/rpc/coalition.rs
@@ -34,7 +34,7 @@ impl CoalitionService for MissionRpc {
         request: Request<coalition::v0::GetPlayerUnitsRequest>,
     ) -> Result<Response<coalition::v0::GetPlayerUnitsResponse>, Status> {
         let res: coalition::v0::GetPlayerUnitsResponse =
-            self.request("getPlayers", request).await?;
+            self.request("getPlayerUnits", request).await?;
         Ok(Response::new(res))
     }
 }

--- a/src/rpc/coalition.rs
+++ b/src/rpc/coalition.rs
@@ -29,11 +29,12 @@ impl CoalitionService for MissionRpc {
         Ok(Response::new(res))
     }
 
-    async fn get_players(
+    async fn get_player_units(
         &self,
-        request: Request<coalition::v0::GetPlayersRequest>,
-    ) -> Result<Response<coalition::v0::GetPlayersResponse>, Status> {
-        let res: coalition::v0::GetPlayersResponse = self.request("getPlayers", request).await?;
+        request: Request<coalition::v0::GetPlayerUnitsRequest>,
+    ) -> Result<Response<coalition::v0::GetPlayerUnitsResponse>, Status> {
+        let res: coalition::v0::GetPlayerUnitsResponse =
+            self.request("getPlayers", request).await?;
         Ok(Response::new(res))
     }
 }


### PR DESCRIPTION
Dealing with the overwrite on the function `getPlayers`. See example from https://github.com/DCS-gRPC/rust-server/issues/114

```
grpcurl.exe -plaintext -import-path ./protos -proto ./protos/dcs/dcs.proto -d '{\"coalition\": 2}' 127.0.0.1:50051 dcs.coalition.v0.CoalitionService/GetPlayerUnits
{
  "units": [
    {
      "id": 814,
      "name": "CV-59 Forrestal - F/A-18C 1",
      "callsign": "Enfield81",
      "coalition": "COALITION_BLUE",
      "type": "FA-18C_hornet",
      "position": {
        "lat": 33.00344509359437,
        "lon": 33.777576937122994,
        "alt": 20.30417251586914
      },
      "playerName": "[OCG] \"Gabs\"",
      "groupName": "CV-59 Forrestal - F/A-18C",
      "numberInGroup": 1,
      "speed": 9.722220053846668,
      "heading": 10.033006398305943,
      "category": "GROUP_CATEGORY_AIRPLANE"
    }
  ]
}
```