### PR TITLE
Add C# headers

### DIFF
--- a/protos/dcs/atmosphere/v0/atmosphere.proto
+++ b/protos/dcs/atmosphere/v0/atmosphere.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package dcs.atmosphere.v0;
 import "dcs/common/v0/common.proto";
+option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Atmosphere";
+
 
 // https://wiki.hoggitworld.com/view/DCS_singleton_atmosphere
 service AtmosphereService {

--- a/protos/dcs/coalition/v0/coalition.proto
+++ b/protos/dcs/coalition/v0/coalition.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package dcs.coalition.v0;
 import "dcs/common/v0/common.proto";
+option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Coalition";
 
 // https://wiki.hoggitworld.com/view/DCS_singleton_coalition
 service CoalitionService {

--- a/protos/dcs/common/v0/common.proto
+++ b/protos/dcs/common/v0/common.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 package dcs.common.v0;
+option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Common";
 
 /**
  * The category the object belongs to

--- a/protos/dcs/controller/v0/controller.proto
+++ b/protos/dcs/controller/v0/controller.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 package dcs.controller.v0;
+option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Controller";
 
 service ControllerService {
   // https://wiki.hoggitworld.com/view/DCS_option_alarmState

--- a/protos/dcs/custom/v0/custom.proto
+++ b/protos/dcs/custom/v0/custom.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 package dcs.custom.v0;
+option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Custom";
 
 // The Custom service is for APIs that do not map to the "standard library" of
 // DCS APIs provided by Eagle Dynamics.

--- a/protos/dcs/group/v0/group.proto
+++ b/protos/dcs/group/v0/group.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package dcs.group.v0;
 import "dcs/common/v0/common.proto";
+option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Group";
 
 // https://wiki.hoggitworld.com/view/DCS_Class_Group
 service GroupService {

--- a/protos/dcs/hook/v0/hook.proto
+++ b/protos/dcs/hook/v0/hook.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 package dcs.hook.v0;
+option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Hook";
 
 // APis that are part of the hook environment
 service HookService {

--- a/protos/dcs/mission/v0/mission.proto
+++ b/protos/dcs/mission/v0/mission.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package dcs.mission.v0;
 import "dcs/common/v0/common.proto";
+option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Mission";
 
 // Contains the streaming APIs that streaming information out of the DCS server.
 service MissionService {

--- a/protos/dcs/net/v0/net.proto
+++ b/protos/dcs/net/v0/net.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package dcs.net.v0;
 import "dcs/common/v0/common.proto";
+option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Net";
 
 service NetService {
   // https://wiki.hoggitworld.com/view/DCS_func_send_chat_to

--- a/protos/dcs/timer/v0/timer.proto
+++ b/protos/dcs/timer/v0/timer.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
-
 package dcs.timer.v0;
+option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Timer";
 
 // https://wiki.hoggitworld.com/view/DCS_singleton_timer
 service TimerService {

--- a/protos/dcs/trigger/v0/trigger.proto
+++ b/protos/dcs/trigger/v0/trigger.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package dcs.trigger.v0;
 import "dcs/common/v0/common.proto";
+option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Trigger";
 
 // https://wiki.hoggitworld.com/view/DCS_singleton_trigger
 service TriggerService {

--- a/protos/dcs/unit/v0/unit.proto
+++ b/protos/dcs/unit/v0/unit.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package dcs.unit.v0;
 import "dcs/common/v0/common.proto";
+option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Unit";
 
 // https://wiki.hoggitworld.com/view/DCS_Class_Unit
 service UnitService {

--- a/protos/dcs/world/v0/world.proto
+++ b/protos/dcs/world/v0/world.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package dcs.world.v0;
 import "dcs/common/v0/common.proto";
+option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.World";
 
 // https://wiki.hoggitworld.com/view/DCS_singleton_world
 service WorldService {


### PR DESCRIPTION
Add headers to the proto files that specify the namespace the generated
C# files will live under. This is part of work to create a simple C#
nuget package so clients to not have to re-invent the wheel in their own
appications.

There are already `Dcs.*` nuget packages so to avoid confusion and
conflict I am putting these under `RurouniJones` as a unique namespace
since we don't have a company or any name that is particularly unique
and I will be publishing other C# DCS related packages so it is as good
a place as any.

-------------

Notes.
I am creating a C# package that I will publish to nuget. I will create a repo in this project called `csharp-client` and I have created a [DCS-gRPC](https://www.nuget.org/organization/DCS-gRPC) organisation on nuget that we can add people to.
