### PR TITLE
chore: add support for go bindings

### DIFF
--- a/protos/dcs/atmosphere/v0/atmosphere.proto
+++ b/protos/dcs/atmosphere/v0/atmosphere.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 package dcs.atmosphere.v0;
 import "dcs/common/v0/common.proto";
 option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Atmosphere";
-
+option go_package = "github.com/DCS-gRPC/go-bindings/dcs/v0/atmosphere";
 
 // https://wiki.hoggitworld.com/view/DCS_singleton_atmosphere
 service AtmosphereService {

--- a/protos/dcs/coalition/v0/coalition.proto
+++ b/protos/dcs/coalition/v0/coalition.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package dcs.coalition.v0;
 import "dcs/common/v0/common.proto";
 option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Coalition";
+option go_package = "github.com/DCS-gRPC/go-bindings/dcs/v0/coalition";
 
 // https://wiki.hoggitworld.com/view/DCS_singleton_coalition
 service CoalitionService {

--- a/protos/dcs/common/v0/common.proto
+++ b/protos/dcs/common/v0/common.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package dcs.common.v0;
 option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Common";
+option go_package = "github.com/DCS-gRPC/go-bindings/dcs/v0/common";
 
 /**
  * The category the object belongs to

--- a/protos/dcs/controller/v0/controller.proto
+++ b/protos/dcs/controller/v0/controller.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package dcs.controller.v0;
 option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Controller";
+option go_package = "github.com/DCS-gRPC/go-bindings/dcs/v0/controller";
 
 service ControllerService {
   // https://wiki.hoggitworld.com/view/DCS_option_alarmState

--- a/protos/dcs/custom/v0/custom.proto
+++ b/protos/dcs/custom/v0/custom.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package dcs.custom.v0;
 option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Custom";
+option go_package = "github.com/DCS-gRPC/go-bindings/dcs/v0/custom";
 
 // The Custom service is for APIs that do not map to the "standard library" of
 // DCS APIs provided by Eagle Dynamics.

--- a/protos/dcs/group/v0/group.proto
+++ b/protos/dcs/group/v0/group.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package dcs.group.v0;
 import "dcs/common/v0/common.proto";
 option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Group";
+option go_package = "github.com/DCS-gRPC/go-bindings/dcs/v0/group";
 
 // https://wiki.hoggitworld.com/view/DCS_Class_Group
 service GroupService {

--- a/protos/dcs/hook/v0/hook.proto
+++ b/protos/dcs/hook/v0/hook.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package dcs.hook.v0;
 option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Hook";
+option go_package = "github.com/DCS-gRPC/go-bindings/dcs/v0/hook";
 
 // APis that are part of the hook environment
 service HookService {

--- a/protos/dcs/mission/v0/mission.proto
+++ b/protos/dcs/mission/v0/mission.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package dcs.mission.v0;
 import "dcs/common/v0/common.proto";
 option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Mission";
+option go_package = "github.com/DCS-gRPC/go-bindings/dcs/v0/mission";
 
 // Contains the streaming APIs that streaming information out of the DCS server.
 service MissionService {

--- a/protos/dcs/net/v0/net.proto
+++ b/protos/dcs/net/v0/net.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package dcs.net.v0;
 import "dcs/common/v0/common.proto";
 option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Net";
+option go_package = "github.com/DCS-gRPC/go-bindings/dcs/v0/net";
 
 service NetService {
   // https://wiki.hoggitworld.com/view/DCS_func_send_chat_to

--- a/protos/dcs/timer/v0/timer.proto
+++ b/protos/dcs/timer/v0/timer.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package dcs.timer.v0;
 option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Timer";
+option go_package = "github.com/DCS-gRPC/go-bindings/dcs/v0/timer";
 
 // https://wiki.hoggitworld.com/view/DCS_singleton_timer
 service TimerService {

--- a/protos/dcs/trigger/v0/trigger.proto
+++ b/protos/dcs/trigger/v0/trigger.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package dcs.trigger.v0;
 import "dcs/common/v0/common.proto";
 option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Trigger";
+option go_package = "github.com/DCS-gRPC/go-bindings/dcs/v0/trigger";
 
 // https://wiki.hoggitworld.com/view/DCS_singleton_trigger
 service TriggerService {

--- a/protos/dcs/unit/v0/unit.proto
+++ b/protos/dcs/unit/v0/unit.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package dcs.unit.v0;
 import "dcs/common/v0/common.proto";
 option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Unit";
+option go_package = "github.com/DCS-gRPC/go-bindings/dcs/v0/unit";
 
 // https://wiki.hoggitworld.com/view/DCS_Class_Unit
 service UnitService {

--- a/protos/dcs/world/v0/world.proto
+++ b/protos/dcs/world/v0/world.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package dcs.world.v0;
 import "dcs/common/v0/common.proto";
 option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.World";
+option go_package = "github.com/DCS-gRPC/go-bindings/dcs/v0/world";
 
 // https://wiki.hoggitworld.com/view/DCS_singleton_world
 service WorldService {


### PR DESCRIPTION
This PR implements support for the go-bindings located at [DCS-gRPC/go-bindings](https://github.com/DCS-gRPC/go-bindings) via the `go_package` protobuf option. Technically this option can be passed via the protoc arguments, but it gets gnarly to manage that (and ofc the google-thinkverse prefers the explicit `go_package` in protos).