### PR TITLE
Add F10 radio mission commands

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -20,4 +20,5 @@ read_globals = {
   "trigger",
   "Unit",
   "world",
+  "missionCommands"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ForcePlayerSlot` API
 - `PlayerChangeSlotEvent` emitted when player changes slot
 - `StreamUnits` can optionally specify the `category` of the units which may be monitored.
+- APIs for creating the F10 radio menus and letting players run them. These will emit events to DCS-gRPC clients when run.
 
 ### Fixed
 - `MarkToCoalition` was sending the mark to the incorrect coalition.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,7 @@ name = "dcs-grpc-stubs"
 version = "0.1.0"
 dependencies = [
  "prost",
+ "prost-types",
  "serde",
  "serde_json",
  "tonic",

--- a/lua/DCS-gRPC/grpc.lua
+++ b/lua/DCS-gRPC/grpc.lua
@@ -131,6 +131,7 @@ GRPC.errorPermissionDenied = function(msg)
   }
 end
 
+GRPC.event = grpc.event
 --
 -- RPC methods
 --

--- a/protos/dcs/mission/v0/mission.proto
+++ b/protos/dcs/mission/v0/mission.proto
@@ -1,8 +1,14 @@
 syntax = "proto3";
 package dcs.mission.v0;
 import "dcs/common/v0/common.proto";
+import "google/protobuf/struct.proto";
 option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Mission";
 option go_package = "github.com/DCS-gRPC/go-bindings/dcs/v0/mission";
+
+// the "path" field in mission command requests and responses is a repeated
+// string however "paths" doesn't make sense. therefore we will disable
+// the linter pluralization checks for this file.
+// protolint:disable REPEATED_FIELD_NAMES_PLURALIZED
 
 // Contains the streaming APIs that streaming information out of the DCS server.
 service MissionService {
@@ -25,6 +31,51 @@ service MissionService {
   // datetime string.
   rpc GetScenarioCurrentTime(GetScenarioCurrentTimeRequest)
       returns (GetScenarioCurrentTimeResponse) {}
+
+  // Adds a new mission command
+  // See https://wiki.hoggitworld.com/view/DCS_func_addCommand
+  rpc AddMissionCommand(AddMissionCommandRequest)
+      returns (AddMissionCommandResponse) {}
+
+  // Adds a new command sub menu
+  // See https://wiki.hoggitworld.com/view/DCS_func_addSubMenu
+  rpc AddMissionCommandSubMenu(AddMissionCommandSubMenuRequest)
+      returns (AddMissionCommandSubMenuResponse) {}
+
+  // Removes a registered mission command.
+  // See https://wiki.hoggitworld.com/view/DCS_func_removeItem
+  rpc RemoveMissionCommandItem(RemoveMissionCommandItemRequest)
+      returns (RemoveMissionCommandItemResponse) {}
+
+  // Adds a new coalition command
+  // See https://wiki.hoggitworld.com/view/DCS_func_addCommandForCoalition
+  rpc AddCoalitionCommand(AddCoalitionCommandRequest)
+      returns (AddCoalitionCommandResponse) {}
+
+  // Adds a new coalition command sub menu
+  // See https://wiki.hoggitworld.com/view/DCS_func_addSubMenuForCoalition
+  rpc AddCoalitionCommandSubMenu(AddCoalitionCommandSubMenuRequest)
+      returns (AddCoalitionCommandSubMenuResponse) {}
+
+  // Removes a registered coalition command.
+  // See https://wiki.hoggitworld.com/view/DCS_func_removeItemForCoalition
+  rpc RemoveCoalitionCommandItem(RemoveCoalitionCommandItemRequest)
+      returns (RemoveCoalitionCommandItemResponse) {}
+
+  // Adds a new group command
+  // See https://wiki.hoggitworld.com/view/DCS_func_addCommandForGroup
+  rpc AddGroupCommand(AddGroupCommandRequest)
+      returns (AddGroupCommandResponse) {}
+
+  // Adds a new group command sub menu
+  // See https://wiki.hoggitworld.com/view/DCS_func_addSubMenuForGroup
+  rpc AddGroupCommandSubMenu(AddGroupCommandSubMenuRequest)
+      returns (AddGroupCommandSubMenuResponse) {}
+
+  // Removes a group coalition command.
+  // See https://wiki.hoggitworld.com/view/DCS_func_removeItemForGroup
+  rpc RemoveGroupCommandItem(RemoveGroupCommandItemRequest)
+      returns (RemoveGroupCommandItemResponse) {}
 }
 
 message StreamEventsRequest {
@@ -373,6 +424,25 @@ message StreamEventsResponse {
     DisconnectReason reason = 2;
   }
 
+  message MissionCommandEvent {
+    // A struct containing details of the command that was run by a player
+    google.protobuf.Struct details = 1;
+  }
+
+  message CoalitionCommandEvent {
+    // The coalition of the player who ran the command
+    dcs.common.v0.Coalition coalition = 1;
+    // A struct containing details of the command that was run by a player
+    google.protobuf.Struct details = 2;
+  }
+
+  message GroupCommandEvent {
+    // The name of the group of the player who ran the command
+    string group_name = 1;
+    // A struct containing details of the command that was run by a player
+    google.protobuf.Struct details = 2;
+  }
+
   // The event's mission time.
   double time = 1;
   oneof event {
@@ -421,6 +491,9 @@ message StreamEventsResponse {
     DisconnectEvent disconnect = 8193;
     PlayerSendChatEvent player_send_chat = 8194;
     PlayerChangeSlotEvent player_change_slot = 8195;
+    MissionCommandEvent mission_command = 8196;
+    CoalitionCommandEvent coalition_command = 8197;
+    GroupCommandEvent group_command = 8198;
   }
 }
 
@@ -470,4 +543,170 @@ message GetScenarioCurrentTimeRequest {
 
 message GetScenarioCurrentTimeResponse {
   string datetime = 1;
+}
+
+// MISSION COMMANDS
+// GLOBAL
+
+// Adds an F10 radio command visible to all players in all coalitions.
+// When the player activates the command then a `missionCommand` event will be
+// emitted to all connected DCS-gRPC clients for processing as they see fit.
+message AddMissionCommandRequest {
+  // The name of the command that is displayed to the player.
+  // It will form the last entry in the returned path.
+  string name = 1;
+  // The menu path the command will appear under. This can be empty if you want
+  // the command to be on the first level under the F10 menu. This path must
+  // already have been created.
+  repeated string path = 2;
+  // A struct containing data that will be included in the emitted event to the
+  // DCS-gRPC clients
+  google.protobuf.Struct details = 3;
+}
+
+message AddMissionCommandResponse {
+  // The full path to the command, including the command name. Use this path to
+  // delete the command.
+  repeated string path = 1;
+}
+
+message AddMissionCommandSubMenuRequest {
+  // The name of the submenu that is displayed to the player.
+  // It will form the last entry in the returned path.
+  string name = 1;
+  // The menu path the submenu will appear under. This can be empty if you want
+  // the submenu to be on the first level under the F10 menu. This path must
+  // already have been created using this command. you cannot create a nested
+  // submenu tree in one command.
+  repeated string path = 2;
+}
+
+message AddMissionCommandSubMenuResponse {
+  // The full path to the submenu, including the submenu name. Use this path to
+  // add another submenu or command underneath it or delete the submenu.
+  repeated string path = 1;
+}
+
+message RemoveMissionCommandItemRequest {
+  // The full path to the menu item, which can be a submenu or a command, to be
+  // removed. Deleting a menu item will delete all children it may have.
+  repeated string path = 1;
+}
+
+message RemoveMissionCommandItemResponse {
+}
+
+// COALITION
+
+// Adds an F10 radio command visible to all players in the specified coalition.
+// When the player activates the command then a `coalitionCommand` event will
+// be emitted to all connected DCS-gRPC clients for processing as they see fit.
+// The emitted event will include the coalition.
+message AddCoalitionCommandRequest {
+  // The coalition whose players will be able to see and run the command
+  dcs.common.v0.Coalition coalition = 1; 
+  // The name of the command that is displayed to the player.
+  // It will form the last entry in the returned path.
+  string name = 2;
+  // The menu path the command will appear under. This can be empty if you want
+  // the command to be on the first level under the F10 menu. This path must
+  // already have been created.
+  repeated string path = 3;
+  // A struct containing data that will be included in the emitted event to the
+  // DCS-gRPC clients
+  google.protobuf.Struct details = 4;
+}
+
+message AddCoalitionCommandResponse {
+  // The full path to the command, including the command name. Use this path to
+  // delete the command.
+  repeated string path = 1;
+}
+
+message AddCoalitionCommandSubMenuRequest {
+  // The coalition whose players will be able to see the submenu
+  dcs.common.v0.Coalition coalition = 1;
+  // The name of the submenu that is displayed to the player.
+  // It will form the last entry in the returned path.
+  string name = 2;
+  // The menu path the submenu will appear under. This can be empty if you want
+  // the submenu to be on the first level under the F10 menu. This path must
+  // already have been created using this command. you cannot create a nested
+  // submenu tree in one command.
+  repeated string path = 3;
+}
+
+message AddCoalitionCommandSubMenuResponse {
+  // The full path to the submenu, including the submenu name. Use this path to
+  // add another submenu or command underneath it or delete the submenu.
+  repeated string path = 1;
+}
+
+message RemoveCoalitionCommandItemRequest {
+  // The coalition whose players will have the menu item removed
+  dcs.common.v0.Coalition coalition = 1; 
+  // The full path to the menu item, which can be a submenu or a command, to be
+  // removed. Deleting a menu item will delete all children it may have.
+  repeated string path = 2;
+}
+
+message RemoveCoalitionCommandItemResponse {
+}
+
+// GROUP
+
+// Adds an F10 radio command visible to all players in the specified group.
+// When the player activates the command then a `groupCommand` event will
+// be emitted to all connected DCS-gRPC clients for processing as they see fit.
+// The emitted event will include the group name.
+message AddGroupCommandRequest {
+  // The name of the group whose players will be able to see and execute the
+  // command. TODO (Figure out if this persists across spawns)
+  string group_name = 1;
+  // The name of the command that is displayed to the player.
+  // It will form the last entry in the returned path.
+  string name = 2;
+  // The menu path the command will appear under. This can be empty if you want
+  // the command to be on the first level under the F10 menu. This path must
+  // already have been created.
+  repeated string path = 3;
+  // A struct containing data that will be included in the emitted event to the
+  // DCS-gRPC clients
+  google.protobuf.Struct details = 4;
+}
+
+message AddGroupCommandResponse {
+  // The full path to the command, including the command name. Use this path to
+  // delete the command.
+  repeated string path = 1;
+}
+
+message AddGroupCommandSubMenuRequest {
+  // The name of the group whose players will be able to see the submenu
+  string group_name = 1;
+  // The name of the submenu that is displayed to the player.
+  // It will form the last entry in the returned path.
+  string name = 2;
+  // The menu path the submenu will appear under. This can be empty if you want
+  // the submenu to be on the first level under the F10 menu. This path must
+  // already have been created using this command. you cannot create a nested
+  // submenu tree in one command.
+  repeated string path = 3;
+}
+
+message AddGroupCommandSubMenuResponse {
+  // The full path to the submenu, including the submenu name. Use this path to
+  // add another submenu or command underneath it or delete the submenu.
+  repeated string path = 1;
+}
+
+message RemoveGroupCommandItemRequest {
+  // The group whose players will have the menu item removed
+  string group_name = 1;
+  // The full path to the menu item, which can be a submenu or a command, to be
+  // removed. Deleting a menu item will delete all children it may have.
+  repeated string path = 2;
+}
+
+message RemoveGroupCommandItemResponse {
 }

--- a/src/rpc/mission.rs
+++ b/src/rpc/mission.rs
@@ -93,6 +93,92 @@ impl MissionService for MissionRpc {
             })?,
         }))
     }
+
+    async fn add_mission_command(
+        &self,
+        request: Request<mission::v0::AddMissionCommandRequest>,
+    ) -> Result<Response<mission::v0::AddMissionCommandResponse>, Status> {
+        let res: mission::v0::AddMissionCommandResponse =
+            self.request("addMissionCommand", request).await?;
+        Ok(Response::new(res))
+    }
+
+    async fn add_mission_command_sub_menu(
+        &self,
+        request: Request<mission::v0::AddMissionCommandSubMenuRequest>,
+    ) -> Result<Response<mission::v0::AddMissionCommandSubMenuResponse>, Status> {
+        let res: mission::v0::AddMissionCommandSubMenuResponse =
+            self.request("addMissionCommandSubMenu", request).await?;
+        Ok(Response::new(res))
+    }
+
+    async fn remove_mission_command_item(
+        &self,
+        request: Request<mission::v0::RemoveMissionCommandItemRequest>,
+    ) -> Result<Response<mission::v0::RemoveMissionCommandItemResponse>, Status> {
+        self.notification("removeMissionCommandItem", request)
+            .await?;
+        Ok(Response::new(
+            mission::v0::RemoveMissionCommandItemResponse {},
+        ))
+    }
+
+    async fn add_coalition_command(
+        &self,
+        request: Request<mission::v0::AddCoalitionCommandRequest>,
+    ) -> Result<Response<mission::v0::AddCoalitionCommandResponse>, Status> {
+        let res: mission::v0::AddCoalitionCommandResponse =
+            self.request("addCoalitionCommand", request).await?;
+        Ok(Response::new(res))
+    }
+
+    async fn add_coalition_command_sub_menu(
+        &self,
+        request: Request<mission::v0::AddCoalitionCommandSubMenuRequest>,
+    ) -> Result<Response<mission::v0::AddCoalitionCommandSubMenuResponse>, Status> {
+        let res: mission::v0::AddCoalitionCommandSubMenuResponse =
+            self.request("addCoalitionCommandSubMenu", request).await?;
+        Ok(Response::new(res))
+    }
+
+    async fn remove_coalition_command_item(
+        &self,
+        request: Request<mission::v0::RemoveCoalitionCommandItemRequest>,
+    ) -> Result<Response<mission::v0::RemoveCoalitionCommandItemResponse>, Status> {
+        self.notification("removeCoalitionCommandItem", request)
+            .await?;
+        Ok(Response::new(
+            mission::v0::RemoveCoalitionCommandItemResponse {},
+        ))
+    }
+
+    async fn add_group_command(
+        &self,
+        request: Request<mission::v0::AddGroupCommandRequest>,
+    ) -> Result<Response<mission::v0::AddGroupCommandResponse>, Status> {
+        let res: mission::v0::AddGroupCommandResponse =
+            self.request("addGroupCommand", request).await?;
+        Ok(Response::new(res))
+    }
+
+    async fn add_group_command_sub_menu(
+        &self,
+        request: Request<mission::v0::AddGroupCommandSubMenuRequest>,
+    ) -> Result<Response<mission::v0::AddGroupCommandSubMenuResponse>, Status> {
+        let res: mission::v0::AddGroupCommandSubMenuResponse =
+            self.request("addGroupCommandSubMenu", request).await?;
+        Ok(Response::new(res))
+    }
+
+    async fn remove_group_command_item(
+        &self,
+        request: Request<mission::v0::RemoveGroupCommandItemRequest>,
+    ) -> Result<Response<mission::v0::RemoveGroupCommandItemResponse>, Status> {
+        self.notification("removeGroupCommandItem", request).await?;
+        Ok(Response::new(
+            mission::v0::RemoveGroupCommandItemResponse {},
+        ))
+    }
 }
 
 impl MissionRpc {

--- a/stubs/Cargo.toml
+++ b/stubs/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.56"
 
 [dependencies]
 prost = "0.9"
+prost-types = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 tonic = "0.6"
 

--- a/stubs/build.rs
+++ b/stubs/build.rs
@@ -20,6 +20,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "dcs.mission.v0.StreamEventsResponse.MarkRemoveEvent.visibility",
             "#[serde(flatten)]",
         )
+        .field_attribute(
+            "dcs.mission.v0.AddMissionCommandRequest.details",
+            r#"#[serde(with = "crate::utils::proto_struct")]"#,
+        )
+        .field_attribute(
+            "dcs.mission.v0.StreamEventsResponse.MissionCommandEvent.details",
+            r#"#[serde(with = "crate::utils::proto_struct")]"#,
+        )
         .build_server(cfg!(feature = "server"))
         .build_client(cfg!(feature = "client"))
         .compile(&["../protos/dcs/dcs.proto"], &["../protos"])?;

--- a/stubs/build.rs
+++ b/stubs/build.rs
@@ -28,6 +28,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "dcs.mission.v0.StreamEventsResponse.MissionCommandEvent.details",
             r#"#[serde(with = "crate::utils::proto_struct")]"#,
         )
+        .field_attribute(
+            "dcs.mission.v0.AddCoalitionCommandRequest.details",
+            r#"#[serde(with = "crate::utils::proto_struct")]"#,
+        )
+        .field_attribute(
+            "dcs.mission.v0.StreamEventsResponse.CoalitionCommandEvent.details",
+            r#"#[serde(with = "crate::utils::proto_struct")]"#,
+        )
+        .field_attribute(
+            "dcs.mission.v0.AddGroupCommandRequest.details",
+            r#"#[serde(with = "crate::utils::proto_struct")]"#,
+        )
+        .field_attribute(
+            "dcs.mission.v0.StreamEventsResponse.GroupCommandEvent.details",
+            r#"#[serde(with = "crate::utils::proto_struct")]"#,
+        )
         .build_server(cfg!(feature = "server"))
         .build_client(cfg!(feature = "client"))
         .compile(&["../protos/dcs/dcs.proto"], &["../protos"])?;

--- a/stubs/src/lib.rs
+++ b/stubs/src/lib.rs
@@ -1,3 +1,5 @@
+mod utils;
+
 pub mod atmosphere {
     pub mod v0 {
         tonic::include_proto!("dcs.atmosphere.v0");

--- a/stubs/src/utils.rs
+++ b/stubs/src/utils.rs
@@ -1,0 +1,411 @@
+/// Methods that can be used to serialize and deserialize [prost_types::Struct].
+pub mod proto_struct {
+    use std::collections::BTreeMap;
+    use std::fmt;
+
+    use prost_types::value::Kind;
+    use prost_types::{ListValue, Struct, Value};
+    use serde::de::{MapAccess, Visitor};
+    use serde::ser::{SerializeMap, SerializeSeq};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S>(data: &Option<Struct>, se: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if let Some(data) = data {
+            StructSe(data).serialize(se)
+        } else {
+            se.serialize_unit()
+        }
+    }
+
+    pub fn deserialize<'de, D>(de: D) -> Result<Option<Struct>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Option::<StructDe>::deserialize(de)?.map(|s| s.0))
+    }
+
+    /// Serializable Wrapper around [prost_types::Struct].
+    struct StructSe<'a>(&'a Struct);
+
+    impl<'a> Serialize for StructSe<'a> {
+        fn serialize<S>(&self, se: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            let mut map = se.serialize_map(Some(self.0.fields.len()))?;
+            for (key, val) in &self.0.fields {
+                map.serialize_key(&key)?;
+                map.serialize_value(&ValueSe(val))?;
+            }
+            map.end()
+        }
+    }
+
+    /// Deserializable Wrapper around [prost_types::Struct].
+    struct StructDe(Struct);
+
+    impl<'de> Deserialize<'de> for StructDe {
+        fn deserialize<D>(de: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            de.deserialize_map(StructVisitor)
+        }
+    }
+
+    /// Serializable Wrapper around [prost_types::Value].
+    struct ValueSe<'a>(&'a Value);
+
+    impl<'a> Serialize for ValueSe<'a> {
+        fn serialize<S>(&self, se: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            if let Some(kind) = &self.0.kind {
+                match kind {
+                    Kind::NullValue(_) => se.serialize_unit(),
+                    Kind::NumberValue(v) => v.serialize(se),
+                    Kind::StringValue(v) => v.serialize(se),
+                    Kind::BoolValue(v) => v.serialize(se),
+                    Kind::StructValue(v) => StructSe(v).serialize(se),
+                    Kind::ListValue(v) => {
+                        let mut seq = se.serialize_seq(Some(v.values.len()))?;
+                        for val in &v.values {
+                            seq.serialize_element(&ValueSe(val))?
+                        }
+                        seq.end()
+                    }
+                }
+            } else {
+                se.serialize_none()
+            }
+        }
+    }
+
+    /// Serializable Wrapper around [prost_types::Value].
+    struct ValueDe(Value);
+
+    impl<'de> Deserialize<'de> for ValueDe {
+        fn deserialize<D>(de: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            de.deserialize_any(ValueVisitor)
+        }
+    }
+
+    struct StructVisitor;
+
+    impl<'de> Visitor<'de> for StructVisitor {
+        type Value = StructDe;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("google.protobuf.Struct")
+        }
+
+        fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
+        where
+            M: MapAccess<'de>,
+        {
+            let mut fields = BTreeMap::new();
+            while let Some((key, value)) = access.next_entry::<String, ValueDe>()? {
+                fields.insert(key, value.0);
+            }
+            Ok(StructDe(Struct { fields }))
+        }
+    }
+
+    struct ValueVisitor;
+
+    impl ValueVisitor {
+        fn visit_number<E>(self, v: impl TryInto<f64>) -> Result<ValueDe, E>
+        where
+            E: serde::de::Error,
+        {
+            v.try_into()
+                .map(|v| {
+                    ValueDe(Value {
+                        kind: Some(Kind::NumberValue(v)),
+                    })
+                })
+                .map_err(|_| {
+                    serde::de::Error::invalid_type(serde::de::Unexpected::Other("f64"), &self)
+                })
+        }
+    }
+
+    impl<'de> Visitor<'de> for ValueVisitor {
+        type Value = ValueDe;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("google.protobuf.Value")
+        }
+
+        fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(ValueDe(Value {
+                kind: Some(Kind::BoolValue(v)),
+            }))
+        }
+
+        fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            self.visit_number(v)
+        }
+
+        fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            self.visit_number(v)
+        }
+
+        fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            self.visit_number(v)
+        }
+
+        fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            i32::try_from(v)
+                .map_err(|_| {
+                    serde::de::Error::invalid_type(serde::de::Unexpected::Other("i64"), &self)
+                })
+                .and_then(|v| self.visit_number(v))
+        }
+
+        fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            i32::try_from(v)
+                .map_err(|_| {
+                    serde::de::Error::invalid_type(serde::de::Unexpected::Other("i64"), &self)
+                })
+                .and_then(|v| self.visit_number(v))
+        }
+
+        fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            self.visit_number(v)
+        }
+
+        fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            self.visit_number(v)
+        }
+
+        fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            self.visit_number(v)
+        }
+
+        fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            u32::try_from(v)
+                .map_err(|_| {
+                    serde::de::Error::invalid_type(serde::de::Unexpected::Other("i64"), &self)
+                })
+                .and_then(|v| self.visit_number(v))
+        }
+
+        fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            u32::try_from(v)
+                .map_err(|_| {
+                    serde::de::Error::invalid_type(serde::de::Unexpected::Other("i64"), &self)
+                })
+                .and_then(|v| self.visit_number(v))
+        }
+
+        fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            self.visit_number(v)
+        }
+
+        fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            self.visit_number(v)
+        }
+
+        fn visit_char<E>(self, v: char) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(ValueDe(Value {
+                kind: Some(Kind::StringValue(v.to_string())),
+            }))
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(ValueDe(Value {
+                kind: Some(Kind::StringValue(v.to_string())),
+            }))
+        }
+
+        fn visit_unit<E>(self) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(ValueDe(Value {
+                kind: Some(Kind::NullValue(0)),
+            }))
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::SeqAccess<'de>,
+        {
+            let mut values = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+            while let Some(val) = seq.next_element::<ValueDe>()? {
+                values.push(val.0);
+            }
+
+            Ok(ValueDe(Value {
+                kind: Some(Kind::ListValue(ListValue { values })),
+            }))
+        }
+
+        fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+        where
+            A: MapAccess<'de>,
+        {
+            Ok(ValueDe(Value {
+                kind: Some(Kind::StructValue(StructVisitor.visit_map(map)?.0)),
+            }))
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use prost_types::value::Kind;
+        use prost_types::{ListValue, Struct, Value};
+
+        #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+        struct Message {
+            #[serde(with = "crate::utils::proto_struct")]
+            details: Option<Struct>,
+        }
+
+        fn create_message(key: impl Into<String>, kind: Kind) -> Message {
+            Message {
+                details: Some(Struct {
+                    fields: [(key.into(), Value { kind: Some(kind) })]
+                        .into_iter()
+                        .collect(),
+                }),
+            }
+        }
+
+        #[test]
+        fn test_null() {
+            let m = create_message("null", Kind::NullValue(0));
+            let json = serde_json::to_string(&m).unwrap();
+            assert_eq!(json, r#"{"details":{"null":null}}"#);
+            assert_eq!(serde_json::from_str::<Message>(&json).unwrap(), m);
+        }
+
+        #[test]
+        fn test_number() {
+            let m = create_message("number", Kind::NumberValue(42.2223));
+            let json = serde_json::to_string(&m).unwrap();
+            assert_eq!(json, r#"{"details":{"number":42.2223}}"#);
+            assert_eq!(serde_json::from_str::<Message>(&json).unwrap(), m);
+        }
+
+        #[test]
+        fn test_string() {
+            let m = create_message("string", Kind::StringValue("dcs-grpc".to_string()));
+            let json = serde_json::to_string(&m).unwrap();
+            assert_eq!(json, r#"{"details":{"string":"dcs-grpc"}}"#);
+            assert_eq!(serde_json::from_str::<Message>(&json).unwrap(), m);
+        }
+
+        #[test]
+        fn test_bool() {
+            let m = create_message("bool", Kind::BoolValue(true));
+            let json = serde_json::to_string(&m).unwrap();
+            assert_eq!(json, r#"{"details":{"bool":true}}"#);
+            assert_eq!(serde_json::from_str::<Message>(&json).unwrap(), m);
+        }
+
+        #[test]
+        fn test_struct() {
+            let m = create_message(
+                "nested",
+                Kind::StructValue(Struct {
+                    fields: [
+                        (
+                            "number".to_string(),
+                            Value {
+                                kind: Some(Kind::NumberValue(42.0)),
+                            },
+                        ),
+                        (
+                            "string".to_string(),
+                            Value {
+                                kind: Some(Kind::StringValue("dcs-grpc".to_string())),
+                            },
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                }),
+            );
+            let json = serde_json::to_string(&m).unwrap();
+            assert_eq!(
+                json,
+                r#"{"details":{"nested":{"number":42.0,"string":"dcs-grpc"}}}"#
+            );
+            assert_eq!(serde_json::from_str::<Message>(&json).unwrap(), m);
+        }
+
+        #[test]
+        fn test_list() {
+            let m = create_message(
+                "list",
+                Kind::ListValue(ListValue {
+                    values: vec![
+                        Value {
+                            kind: Some(Kind::NumberValue(42.0)),
+                        },
+                        Value {
+                            kind: Some(Kind::StringValue("dcs-grpc".to_string())),
+                        },
+                    ],
+                }),
+            );
+            let json = serde_json::to_string(&m).unwrap();
+            assert_eq!(json, r#"{"details":{"list":[42.0,"dcs-grpc"]}}"#);
+            assert_eq!(serde_json::from_str::<Message>(&json).unwrap(), m);
+        }
+    }
+}


### PR DESCRIPTION
    Add MissionCommand API support

    Add support for the `AddMissionCommand`, `AddMissionCommandSubMenu` and
    `RemoveMissionCommandItem` APIs along with their Coalition and Group
    variants which allow us to create F10 radio command menu entries and
    have them emit events to DCS-gRPC clients.

    Additionally it adds new CommandEvents which are triggered for
    any execution of a command via the F10 radio menu by the players.