### PR TITLE
Add leading semi-colon to cpath

### DIFF
--- a/lua/DCS-gRPC/grpc-hook.lua
+++ b/lua/DCS-gRPC/grpc-hook.lua
@@ -4,7 +4,7 @@ local function load()
 
   -- Let DCS know where to find the DLLs
   if not string.find(package.cpath, GRPC.dllPath) then
-    package.cpath = package.cpath .. GRPC.dllPath .. [[?.dll;]]
+    package.cpath = package.cpath .. [[;]] .. GRPC.dllPath .. [[?.dll;]]
   end
 
   local ok, grpc = pcall(require, "dcs_grpc_hot_reload")

--- a/lua/DCS-gRPC/grpc-mission.lua
+++ b/lua/DCS-gRPC/grpc-mission.lua
@@ -29,7 +29,7 @@ end
 
 -- Let DCS know where to find the DLLs
 if not string.find(package.cpath, GRPC.dllPath) then
-  package.cpath = package.cpath .. GRPC.dllPath .. [[?.dll;]]
+  package.cpath = package.cpath .. [[;]] .. GRPC.dllPath .. [[?.dll;]]
 end
 
 -- Load DLL before `require` gets sanitized.


### PR DESCRIPTION
Add a leading semi-colon to the cpath when adding our entry. This is
purely defensive programming and protects us if other lua code forgets
to add a semi-colon at the end of their entry.