### PR TITLE
Add more detail to `GroupCommand` event.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Replaced `groupName` field in the `GroupCommand` event with all the group details as exposed by the group exporter
+  (currently id, name, coalition, category). This change was made based on experience writing a client that processes these events
+  where only having the groupName was a limitation. This change breaks backwards compatibility with 0.4.0 where the `GroupCommand`
+  event was first added.
+
 ## [0.4.0] - 2022-03-07
 ### Added
 - `ForcePlayerSlot` API

--- a/lua/DCS-gRPC/methods/mission.lua
+++ b/lua/DCS-gRPC/methods/mission.lua
@@ -487,7 +487,7 @@ end
 local function groupCommandCallback(params)
   local event = {
     type = "groupCommand",
-    groupName = params.groupName,
+    group = GRPC.exporters.group(params.group),
     details = params.details,
   }
 
@@ -502,6 +502,7 @@ GRPC.methods.addGroupCommand = function(params)
   if group == nil then
     return GRPC.errorNotFound("group does not exist")
   end
+  params['group'] = group
 
   return GRPC.success({
     path = missionCommands.addCommandForGroup(group:getID(), params.name, params.path,

--- a/protos/dcs/mission/v0/mission.proto
+++ b/protos/dcs/mission/v0/mission.proto
@@ -437,8 +437,8 @@ message StreamEventsResponse {
   }
 
   message GroupCommandEvent {
-    // The name of the group of the player who ran the command
-    string group_name = 1;
+    // Details of the group to which the player who ran the command is a unit of
+    dcs.common.v0.Group group = 1;
     // A struct containing details of the command that was run by a player
     google.protobuf.Struct details = 2;
   }


### PR DESCRIPTION
Replace `groupName` field in the `GroupCommand` event with all the group
details as exposed by the group exporter (currently id, name, coalition
and category).

This change was made based on experience writing a client that processes
these events where only having the groupName was a limitation.

This change breaks backwards compatibility with version 0.4.0 where the
`GroupCommand` event was first added.