### PR TITLE
remove ipc notification usages

### DIFF
--- a/lua/DCS-gRPC/methods/controllers.lua
+++ b/lua/DCS-gRPC/methods/controllers.lua
@@ -28,5 +28,5 @@ GRPC.methods.setAlarmState = function(params)
 
   controller:setOption(state_id, params.alarmState - 1)
 
-  return GRPC.success(nil)
+  return GRPC.success({})
 end

--- a/lua/DCS-gRPC/methods/hook.lua
+++ b/lua/DCS-gRPC/methods/hook.lua
@@ -23,17 +23,17 @@ end
 
 GRPC.methods.setPaused = function(params)
   DCS.setPause(params.paused)
-  return GRPC.success(nil)
+  return GRPC.success({})
 end
 
 GRPC.methods.stopMission = function()
   DCS.stopMission()
-  return GRPC.success(nil)
+  return GRPC.success({})
 end
 
 GRPC.methods.exitProcess = function()
   DCS.exitProcess()
-  return GRPC.success(nil)
+  return GRPC.success({})
 end
 
 GRPC.methods.hookEval = function(params)

--- a/lua/DCS-gRPC/methods/mission.lua
+++ b/lua/DCS-gRPC/methods/mission.lua
@@ -443,7 +443,7 @@ end
 
 GRPC.methods.removeMissionCommandItem = function(params)
   missionCommands.removeItem(params.path)
-  return GRPC.success(nil)
+  return GRPC.success({})
 end
 
 -- Coalition Level Commands
@@ -479,7 +479,7 @@ end
 GRPC.methods.removeCoalitionCommandItem = function(params)
   -- Decrement coalition for non zero-indexed gRPC enum
   missionCommands.removeItemForCoalition(params.coalition - 1, params.path)
-  return GRPC.success(nil)
+  return GRPC.success({})
 end
 
 -- Group Level Commands
@@ -528,5 +528,5 @@ GRPC.methods.removeGroupCommandItem = function(params)
   end
 
   missionCommands.removeItemForGroup(group:getID(), params.path)
-  return GRPC.success(nil)
+  return GRPC.success({})
 end

--- a/lua/DCS-gRPC/methods/net.lua
+++ b/lua/DCS-gRPC/methods/net.lua
@@ -8,7 +8,7 @@ GRPC.methods.sendChatTo = function(params)
     --       due to the magnitude of a social attack vector.
     --       https://github.com/DCS-gRPC/rust-server/pull/94#discussion_r780777794
     net.send_chat_to(params.message, params.targetPlayerId)
-    return GRPC.success(nil)
+    return GRPC.success({})
 end
 
 GRPC.methods.sendChat = function(params)
@@ -18,7 +18,7 @@ GRPC.methods.sendChat = function(params)
 
     local toAll = params.coalition ~= 1
     net.send_chat(params.message, toAll)
-    return GRPC.success(nil)
+    return GRPC.success({})
 end
 
 GRPC.methods.getPlayers = function()
@@ -50,7 +50,7 @@ GRPC.methods.forcePlayerSlot = function(params)
     local normalizedCoalition = params.coalition - 1; -- adjusted for grpc offset
     net.force_player_slot(params.playerId, normalizedCoalition, params.slotId)
 
-    return GRPC.success(nil)
+    return GRPC.success({})
 end
 
 GRPC.methods.kickPlayer = function(params)
@@ -65,5 +65,5 @@ GRPC.methods.kickPlayer = function(params)
   end
 
   net.kick(params.id, params.message)
-  return GRPC.success(nil)
+  return GRPC.success({})
 end

--- a/lua/DCS-gRPC/methods/trigger.lua
+++ b/lua/DCS-gRPC/methods/trigger.lua
@@ -26,7 +26,7 @@ end
 GRPC.methods.outText = function(params)
   trigger.action.outText(params.text, params.displayTime, params.clearView)
 
-  return GRPC.success(nil)
+  return GRPC.success({})
 end
 
 GRPC.methods.outTextForCoalition = function(params)
@@ -37,13 +37,13 @@ GRPC.methods.outTextForCoalition = function(params)
   -- Decrement for non zero-indexed gRPC enum
   trigger.action.outTextForCoalition(params.coalition - 1, params.text, params.displayTime, params.clearView)
 
-  return GRPC.success(nil)
+  return GRPC.success({})
 end
 
 GRPC.methods.outTextForGroup = function(params)
   trigger.action.outTextForGroup(params.groupId, params.text, params.displayTime, params.clearView)
 
-  return GRPC.success(nil)
+  return GRPC.success({})
 end
 
 GRPC.methods.getUserFlag = function(params)
@@ -54,7 +54,7 @@ end
 
 GRPC.methods.setUserFlag = function(params)
   trigger.action.setUserFlag(params.flag, params.value)
-  return GRPC.success(nil)
+  return GRPC.success({})
 end
 
 GRPC.methods.markToAll = function(params)
@@ -94,7 +94,7 @@ end
 GRPC.methods.removeMark = function(params)
   trigger.action.removeMark(params.id)
 
-  return GRPC.success(nil)
+  return GRPC.success({})
 end
 
 GRPC.methods.explosion = function(params)
@@ -102,7 +102,7 @@ GRPC.methods.explosion = function(params)
 
   trigger.action.explosion(point, params.power)
 
-  return GRPC.success(nil)
+  return GRPC.success({})
 end
 
 -- gRPC enums should avoid 0 so we increment it there and then subtract by 1
@@ -120,7 +120,7 @@ GRPC.methods.smoke = function(params)
 
   trigger.action.smoke(groundPoint, params.color - 1)
 
-  return GRPC.success(nil)
+  return GRPC.success({})
 end
 
 GRPC.methods.illuminationBomb = function(params)
@@ -133,7 +133,7 @@ GRPC.methods.illuminationBomb = function(params)
 
   trigger.action.illuminationBomb(groundOffsetPoint, params.power)
 
-  return GRPC.success(nil)
+  return GRPC.success({})
 end
 
 -- gRPC enums should avoid 0 so we increment it there and then subtract by 1
@@ -150,5 +150,5 @@ GRPC.methods.signalFlare = function(params)
 
   trigger.action.signalFlare(groundPoint, params.color - 1, params.azimuth)
 
-  return GRPC.success(nil)
+  return GRPC.success({})
 end

--- a/lua/DCS-gRPC/methods/unit.lua
+++ b/lua/DCS-gRPC/methods/unit.lua
@@ -123,7 +123,7 @@ GRPC.methods.setEmission = function(params)
   if unit == nil then
     return GRPC.errorNotFound("unit does not exist")
   end  unit:enableEmission(params.emitting)
-  return GRPC.success(nil)
+  return GRPC.success({})
 end
 
 GRPC.methods.getUnit = function(params)

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -74,17 +74,6 @@ impl MissionRpc {
             .map_err(to_status)
     }
 
-    pub async fn notification<I>(&self, method: &str, request: Request<I>) -> Result<(), Status>
-    where
-        I: serde::Serialize + Send + Sync + 'static,
-    {
-        let _guard = self.stats.track_queue_size();
-        self.ipc
-            .notification(method, Some(request.into_inner()))
-            .await
-            .map_err(to_status)
-    }
-
     pub async fn events(&self) -> impl Stream<Item = StreamEventsResponse> {
         self.ipc.events().await
     }
@@ -112,17 +101,6 @@ impl HookRpc {
         let _guard = self.stats.track_queue_size();
         self.ipc
             .request(method, Some(request.into_inner()))
-            .await
-            .map_err(to_status)
-    }
-
-    pub async fn notification<I>(&self, method: &str, request: Request<I>) -> Result<(), Status>
-    where
-        I: serde::Serialize + Send + Sync + 'static,
-    {
-        let _guard = self.stats.track_queue_size();
-        self.ipc
-            .notification(method, Some(request.into_inner()))
             .await
             .map_err(to_status)
     }

--- a/src/rpc/atmosphere.rs
+++ b/src/rpc/atmosphere.rs
@@ -32,8 +32,7 @@ impl AtmosphereService for MissionRpc {
         &self,
         request: Request<atmosphere::v0::GetTemperatureAndPressureRequest>,
     ) -> Result<Response<atmosphere::v0::GetTemperatureAndPressureResponse>, Status> {
-        let res: atmosphere::v0::GetTemperatureAndPressureResponse =
-            self.request("getTemperatureAndPressure", request).await?;
+        let res = self.request("getTemperatureAndPressure", request).await?;
         Ok(Response::new(res))
     }
 }

--- a/src/rpc/coalition.rs
+++ b/src/rpc/coalition.rs
@@ -9,7 +9,7 @@ impl CoalitionService for MissionRpc {
         &self,
         request: Request<coalition::v0::AddGroupRequest>,
     ) -> Result<Response<coalition::v0::AddGroupResponse>, Status> {
-        let res: coalition::v0::AddGroupResponse = self.request("addGroup", request).await?;
+        let res = self.request("addGroup", request).await?;
         Ok(Response::new(res))
     }
 
@@ -17,7 +17,7 @@ impl CoalitionService for MissionRpc {
         &self,
         request: Request<coalition::v0::GetGroupsRequest>,
     ) -> Result<Response<coalition::v0::GetGroupsResponse>, Status> {
-        let res: coalition::v0::GetGroupsResponse = self.request("getGroups", request).await?;
+        let res = self.request("getGroups", request).await?;
         Ok(Response::new(res))
     }
 
@@ -25,7 +25,7 @@ impl CoalitionService for MissionRpc {
         &self,
         request: Request<coalition::v0::GetBullseyeRequest>,
     ) -> Result<Response<coalition::v0::GetBullseyeResponse>, Status> {
-        let res: coalition::v0::GetBullseyeResponse = self.request("getBullseye", request).await?;
+        let res = self.request("getBullseye", request).await?;
         Ok(Response::new(res))
     }
 
@@ -33,8 +33,7 @@ impl CoalitionService for MissionRpc {
         &self,
         request: Request<coalition::v0::GetPlayerUnitsRequest>,
     ) -> Result<Response<coalition::v0::GetPlayerUnitsResponse>, Status> {
-        let res: coalition::v0::GetPlayerUnitsResponse =
-            self.request("getPlayerUnits", request).await?;
+        let res = self.request("getPlayerUnits", request).await?;
         Ok(Response::new(res))
     }
 }

--- a/src/rpc/controller.rs
+++ b/src/rpc/controller.rs
@@ -9,7 +9,7 @@ impl ControllerService for MissionRpc {
         &self,
         request: Request<controller::v0::SetAlarmStateRequest>,
     ) -> Result<Response<controller::v0::SetAlarmStateResponse>, Status> {
-        self.request("setAlarmState", request).await?;
-        Ok(Response::new(controller::v0::SetAlarmStateResponse {}))
+        let res = self.request("setAlarmState", request).await?;
+        Ok(Response::new(res))
     }
 }

--- a/src/rpc/controller.rs
+++ b/src/rpc/controller.rs
@@ -9,7 +9,7 @@ impl ControllerService for MissionRpc {
         &self,
         request: Request<controller::v0::SetAlarmStateRequest>,
     ) -> Result<Response<controller::v0::SetAlarmStateResponse>, Status> {
-        self.notification("setAlarmState", request).await?;
+        self.request("setAlarmState", request).await?;
         Ok(Response::new(controller::v0::SetAlarmStateResponse {}))
     }
 }

--- a/src/rpc/custom.rs
+++ b/src/rpc/custom.rs
@@ -11,8 +11,7 @@ impl CustomService for MissionRpc {
         &self,
         request: Request<custom::v0::RequestMissionAssignmentRequest>,
     ) -> Result<Response<custom::v0::RequestMissionAssignmentResponse>, Status> {
-        self.notification("requestMissionAssignment", request)
-            .await?;
+        self.request("requestMissionAssignment", request).await?;
         Ok(Response::new(
             custom::v0::RequestMissionAssignmentResponse {},
         ))
@@ -22,7 +21,7 @@ impl CustomService for MissionRpc {
         &self,
         request: Request<custom::v0::JoinMissionRequest>,
     ) -> Result<Response<custom::v0::JoinMissionResponse>, Status> {
-        self.notification("joinMission", request).await?;
+        self.request("joinMission", request).await?;
         Ok(Response::new(custom::v0::JoinMissionResponse {}))
     }
 
@@ -30,7 +29,7 @@ impl CustomService for MissionRpc {
         &self,
         request: Request<custom::v0::AbortMissionRequest>,
     ) -> Result<Response<custom::v0::AbortMissionResponse>, Status> {
-        self.notification("abortMission", request).await?;
+        self.request("abortMission", request).await?;
         Ok(Response::new(custom::v0::AbortMissionResponse {}))
     }
 
@@ -38,7 +37,7 @@ impl CustomService for MissionRpc {
         &self,
         request: Request<custom::v0::GetMissionStatusRequest>,
     ) -> Result<Response<custom::v0::GetMissionStatusResponse>, Status> {
-        self.notification("getMissionStatus", request).await?;
+        self.request("getMissionStatus", request).await?;
         Ok(Response::new(custom::v0::GetMissionStatusResponse {}))
     }
 

--- a/src/rpc/custom.rs
+++ b/src/rpc/custom.rs
@@ -11,34 +11,32 @@ impl CustomService for MissionRpc {
         &self,
         request: Request<custom::v0::RequestMissionAssignmentRequest>,
     ) -> Result<Response<custom::v0::RequestMissionAssignmentResponse>, Status> {
-        self.request("requestMissionAssignment", request).await?;
-        Ok(Response::new(
-            custom::v0::RequestMissionAssignmentResponse {},
-        ))
+        let res = self.request("requestMissionAssignment", request).await?;
+        Ok(Response::new(res))
     }
 
     async fn join_mission(
         &self,
         request: Request<custom::v0::JoinMissionRequest>,
     ) -> Result<Response<custom::v0::JoinMissionResponse>, Status> {
-        self.request("joinMission", request).await?;
-        Ok(Response::new(custom::v0::JoinMissionResponse {}))
+        let res = self.request("joinMission", request).await?;
+        Ok(Response::new(res))
     }
 
     async fn abort_mission(
         &self,
         request: Request<custom::v0::AbortMissionRequest>,
     ) -> Result<Response<custom::v0::AbortMissionResponse>, Status> {
-        self.request("abortMission", request).await?;
-        Ok(Response::new(custom::v0::AbortMissionResponse {}))
+        let res = self.request("abortMission", request).await?;
+        Ok(Response::new(res))
     }
 
     async fn get_mission_status(
         &self,
         request: Request<custom::v0::GetMissionStatusRequest>,
     ) -> Result<Response<custom::v0::GetMissionStatusResponse>, Status> {
-        self.request("getMissionStatus", request).await?;
-        Ok(Response::new(custom::v0::GetMissionStatusResponse {}))
+        let res = self.request("getMissionStatus", request).await?;
+        Ok(Response::new(res))
     }
 
     async fn eval(

--- a/src/rpc/group.rs
+++ b/src/rpc/group.rs
@@ -9,7 +9,7 @@ impl GroupService for MissionRpc {
         &self,
         request: Request<group::v0::GetUnitsRequest>,
     ) -> Result<Response<group::v0::GetUnitsResponse>, Status> {
-        let res: group::v0::GetUnitsResponse = self.request("getUnits", request).await?;
+        let res = self.request("getUnits", request).await?;
         Ok(Response::new(res))
     }
 }

--- a/src/rpc/hook.rs
+++ b/src/rpc/hook.rs
@@ -9,7 +9,7 @@ impl HookService for HookRpc {
         &self,
         request: Request<hook::v0::GetMissionNameRequest>,
     ) -> Result<Response<hook::v0::GetMissionNameResponse>, Status> {
-        let res: hook::v0::GetMissionNameResponse = self.request("getMissionName", request).await?;
+        let res = self.request("getMissionName", request).await?;
         Ok(Response::new(res))
     }
 
@@ -17,8 +17,7 @@ impl HookService for HookRpc {
         &self,
         request: Request<hook::v0::GetMissionDescriptionRequest>,
     ) -> Result<Response<hook::v0::GetMissionDescriptionResponse>, Status> {
-        let res: hook::v0::GetMissionDescriptionResponse =
-            self.request("getMissionDescription", request).await?;
+        let res = self.request("getMissionDescription", request).await?;
         Ok(Response::new(res))
     }
 
@@ -26,8 +25,7 @@ impl HookService for HookRpc {
         &self,
         request: Request<hook::v0::GetMissionFilenameRequest>,
     ) -> Result<Response<hook::v0::GetMissionFilenameResponse>, Status> {
-        let res: hook::v0::GetMissionFilenameResponse =
-            self.request("getMissionFilename", request).await?;
+        let res = self.request("getMissionFilename", request).await?;
         Ok(Response::new(res))
     }
 
@@ -35,7 +33,7 @@ impl HookService for HookRpc {
         &self,
         request: Request<hook::v0::GetPausedRequest>,
     ) -> Result<Response<hook::v0::GetPausedResponse>, Status> {
-        let res: hook::v0::GetPausedResponse = self.request("getPaused", request).await?;
+        let res = self.request("getPaused", request).await?;
         Ok(Response::new(res))
     }
 
@@ -43,16 +41,16 @@ impl HookService for HookRpc {
         &self,
         request: Request<hook::v0::SetPausedRequest>,
     ) -> Result<Response<hook::v0::SetPausedResponse>, Status> {
-        self.request("setPaused", request).await?;
-        Ok(Response::new(hook::v0::SetPausedResponse {}))
+        let res = self.request("setPaused", request).await?;
+        Ok(Response::new(res))
     }
 
     async fn stop_mission(
         &self,
         request: Request<hook::v0::StopMissionRequest>,
     ) -> Result<Response<hook::v0::StopMissionResponse>, Status> {
-        self.request("stopMission", request).await?;
-        Ok(Response::new(hook::v0::StopMissionResponse {}))
+        let res = self.request("stopMission", request).await?;
+        Ok(Response::new(res))
     }
 
     async fn eval(
@@ -74,15 +72,15 @@ impl HookService for HookRpc {
         &self,
         request: Request<hook::v0::ExitProcessRequest>,
     ) -> Result<Response<hook::v0::ExitProcessResponse>, Status> {
-        self.request("exitProcess", request).await?;
-        Ok(Response::new(hook::v0::ExitProcessResponse {}))
+        let res = self.request("exitProcess", request).await?;
+        Ok(Response::new(res))
     }
 
     async fn is_multiplayer(
         &self,
         request: Request<hook::v0::IsMultiplayerRequest>,
     ) -> Result<Response<hook::v0::IsMultiplayerResponse>, Status> {
-        let res: hook::v0::IsMultiplayerResponse = self.request("isMultiplayer", request).await?;
+        let res = self.request("isMultiplayer", request).await?;
         Ok(Response::new(res))
     }
 
@@ -90,7 +88,7 @@ impl HookService for HookRpc {
         &self,
         request: Request<hook::v0::IsServerRequest>,
     ) -> Result<Response<hook::v0::IsServerResponse>, Status> {
-        let res: hook::v0::IsServerResponse = self.request("isServer", request).await?;
+        let res = self.request("isServer", request).await?;
         Ok(Response::new(res))
     }
 
@@ -98,7 +96,7 @@ impl HookService for HookRpc {
         &self,
         request: Request<hook::v0::BanPlayerRequest>,
     ) -> Result<Response<hook::v0::BanPlayerResponse>, Status> {
-        let res: hook::v0::BanPlayerResponse = self.request("banPlayer", request).await?;
+        let res = self.request("banPlayer", request).await?;
         Ok(Response::new(res))
     }
 
@@ -106,7 +104,7 @@ impl HookService for HookRpc {
         &self,
         request: Request<hook::v0::UnbanPlayerRequest>,
     ) -> Result<Response<hook::v0::UnbanPlayerResponse>, Status> {
-        let res: hook::v0::UnbanPlayerResponse = self.request("unbanPlayer", request).await?;
+        let res = self.request("unbanPlayer", request).await?;
         Ok(Response::new(res))
     }
 
@@ -114,8 +112,7 @@ impl HookService for HookRpc {
         &self,
         request: Request<hook::v0::GetBannedPlayersRequest>,
     ) -> Result<Response<hook::v0::GetBannedPlayersResponse>, Status> {
-        let res: hook::v0::GetBannedPlayersResponse =
-            self.request("getBannedPlayers", request).await?;
+        let res = self.request("getBannedPlayers", request).await?;
         Ok(Response::new(res))
     }
 }

--- a/src/rpc/hook.rs
+++ b/src/rpc/hook.rs
@@ -43,7 +43,7 @@ impl HookService for HookRpc {
         &self,
         request: Request<hook::v0::SetPausedRequest>,
     ) -> Result<Response<hook::v0::SetPausedResponse>, Status> {
-        self.notification("setPaused", request).await?;
+        self.request("setPaused", request).await?;
         Ok(Response::new(hook::v0::SetPausedResponse {}))
     }
 
@@ -51,7 +51,7 @@ impl HookService for HookRpc {
         &self,
         request: Request<hook::v0::StopMissionRequest>,
     ) -> Result<Response<hook::v0::StopMissionResponse>, Status> {
-        self.notification("stopMission", request).await?;
+        self.request("stopMission", request).await?;
         Ok(Response::new(hook::v0::StopMissionResponse {}))
     }
 
@@ -74,7 +74,7 @@ impl HookService for HookRpc {
         &self,
         request: Request<hook::v0::ExitProcessRequest>,
     ) -> Result<Response<hook::v0::ExitProcessResponse>, Status> {
-        self.notification("exitProcess", request).await?;
+        self.request("exitProcess", request).await?;
         Ok(Response::new(hook::v0::ExitProcessResponse {}))
     }
 

--- a/src/rpc/mission.rs
+++ b/src/rpc/mission.rs
@@ -98,8 +98,7 @@ impl MissionService for MissionRpc {
         &self,
         request: Request<mission::v0::AddMissionCommandRequest>,
     ) -> Result<Response<mission::v0::AddMissionCommandResponse>, Status> {
-        let res: mission::v0::AddMissionCommandResponse =
-            self.request("addMissionCommand", request).await?;
+        let res = self.request("addMissionCommand", request).await?;
         Ok(Response::new(res))
     }
 
@@ -107,8 +106,7 @@ impl MissionService for MissionRpc {
         &self,
         request: Request<mission::v0::AddMissionCommandSubMenuRequest>,
     ) -> Result<Response<mission::v0::AddMissionCommandSubMenuResponse>, Status> {
-        let res: mission::v0::AddMissionCommandSubMenuResponse =
-            self.request("addMissionCommandSubMenu", request).await?;
+        let res = self.request("addMissionCommandSubMenu", request).await?;
         Ok(Response::new(res))
     }
 
@@ -116,18 +114,15 @@ impl MissionService for MissionRpc {
         &self,
         request: Request<mission::v0::RemoveMissionCommandItemRequest>,
     ) -> Result<Response<mission::v0::RemoveMissionCommandItemResponse>, Status> {
-        self.request("removeMissionCommandItem", request).await?;
-        Ok(Response::new(
-            mission::v0::RemoveMissionCommandItemResponse {},
-        ))
+        let res = self.request("removeMissionCommandItem", request).await?;
+        Ok(Response::new(res))
     }
 
     async fn add_coalition_command(
         &self,
         request: Request<mission::v0::AddCoalitionCommandRequest>,
     ) -> Result<Response<mission::v0::AddCoalitionCommandResponse>, Status> {
-        let res: mission::v0::AddCoalitionCommandResponse =
-            self.request("addCoalitionCommand", request).await?;
+        let res = self.request("addCoalitionCommand", request).await?;
         Ok(Response::new(res))
     }
 
@@ -135,8 +130,7 @@ impl MissionService for MissionRpc {
         &self,
         request: Request<mission::v0::AddCoalitionCommandSubMenuRequest>,
     ) -> Result<Response<mission::v0::AddCoalitionCommandSubMenuResponse>, Status> {
-        let res: mission::v0::AddCoalitionCommandSubMenuResponse =
-            self.request("addCoalitionCommandSubMenu", request).await?;
+        let res = self.request("addCoalitionCommandSubMenu", request).await?;
         Ok(Response::new(res))
     }
 
@@ -144,18 +138,15 @@ impl MissionService for MissionRpc {
         &self,
         request: Request<mission::v0::RemoveCoalitionCommandItemRequest>,
     ) -> Result<Response<mission::v0::RemoveCoalitionCommandItemResponse>, Status> {
-        self.request("removeCoalitionCommandItem", request).await?;
-        Ok(Response::new(
-            mission::v0::RemoveCoalitionCommandItemResponse {},
-        ))
+        let res = self.request("removeCoalitionCommandItem", request).await?;
+        Ok(Response::new(res))
     }
 
     async fn add_group_command(
         &self,
         request: Request<mission::v0::AddGroupCommandRequest>,
     ) -> Result<Response<mission::v0::AddGroupCommandResponse>, Status> {
-        let res: mission::v0::AddGroupCommandResponse =
-            self.request("addGroupCommand", request).await?;
+        let res = self.request("addGroupCommand", request).await?;
         Ok(Response::new(res))
     }
 
@@ -163,8 +154,7 @@ impl MissionService for MissionRpc {
         &self,
         request: Request<mission::v0::AddGroupCommandSubMenuRequest>,
     ) -> Result<Response<mission::v0::AddGroupCommandSubMenuResponse>, Status> {
-        let res: mission::v0::AddGroupCommandSubMenuResponse =
-            self.request("addGroupCommandSubMenu", request).await?;
+        let res = self.request("addGroupCommandSubMenu", request).await?;
         Ok(Response::new(res))
     }
 
@@ -172,10 +162,8 @@ impl MissionService for MissionRpc {
         &self,
         request: Request<mission::v0::RemoveGroupCommandItemRequest>,
     ) -> Result<Response<mission::v0::RemoveGroupCommandItemResponse>, Status> {
-        self.request("removeGroupCommandItem", request).await?;
-        Ok(Response::new(
-            mission::v0::RemoveGroupCommandItemResponse {},
-        ))
+        let res = self.request("removeGroupCommandItem", request).await?;
+        Ok(Response::new(res))
     }
 }
 

--- a/src/rpc/mission.rs
+++ b/src/rpc/mission.rs
@@ -116,8 +116,7 @@ impl MissionService for MissionRpc {
         &self,
         request: Request<mission::v0::RemoveMissionCommandItemRequest>,
     ) -> Result<Response<mission::v0::RemoveMissionCommandItemResponse>, Status> {
-        self.notification("removeMissionCommandItem", request)
-            .await?;
+        self.request("removeMissionCommandItem", request).await?;
         Ok(Response::new(
             mission::v0::RemoveMissionCommandItemResponse {},
         ))
@@ -145,8 +144,7 @@ impl MissionService for MissionRpc {
         &self,
         request: Request<mission::v0::RemoveCoalitionCommandItemRequest>,
     ) -> Result<Response<mission::v0::RemoveCoalitionCommandItemResponse>, Status> {
-        self.notification("removeCoalitionCommandItem", request)
-            .await?;
+        self.request("removeCoalitionCommandItem", request).await?;
         Ok(Response::new(
             mission::v0::RemoveCoalitionCommandItemResponse {},
         ))
@@ -174,7 +172,7 @@ impl MissionService for MissionRpc {
         &self,
         request: Request<mission::v0::RemoveGroupCommandItemRequest>,
     ) -> Result<Response<mission::v0::RemoveGroupCommandItemResponse>, Status> {
-        self.notification("removeGroupCommandItem", request).await?;
+        self.request("removeGroupCommandItem", request).await?;
         Ok(Response::new(
             mission::v0::RemoveGroupCommandItemResponse {},
         ))

--- a/src/rpc/net.rs
+++ b/src/rpc/net.rs
@@ -9,7 +9,7 @@ impl NetService for MissionRpc {
         &self,
         request: Request<net::v0::SendChatToRequest>,
     ) -> Result<Response<net::v0::SendChatToResponse>, Status> {
-        self.notification("sendChatTo", request).await?;
+        self.request("sendChatTo", request).await?;
         Ok(Response::new(net::v0::SendChatToResponse {}))
     }
 
@@ -17,7 +17,7 @@ impl NetService for MissionRpc {
         &self,
         request: Request<net::v0::SendChatRequest>,
     ) -> Result<Response<net::v0::SendChatResponse>, Status> {
-        self.notification("sendChat", request).await?;
+        self.request("sendChat", request).await?;
         Ok(Response::new(net::v0::SendChatResponse {}))
     }
 
@@ -33,7 +33,7 @@ impl NetService for MissionRpc {
         &self,
         request: Request<net::v0::ForcePlayerSlotRequest>,
     ) -> Result<Response<net::v0::ForcePlayerSlotResponse>, Status> {
-        self.notification("forcePlayerSlot", request).await?;
+        self.request("forcePlayerSlot", request).await?;
         Ok(Response::new(net::v0::ForcePlayerSlotResponse {}))
     }
 

--- a/src/rpc/net.rs
+++ b/src/rpc/net.rs
@@ -9,23 +9,23 @@ impl NetService for MissionRpc {
         &self,
         request: Request<net::v0::SendChatToRequest>,
     ) -> Result<Response<net::v0::SendChatToResponse>, Status> {
-        self.request("sendChatTo", request).await?;
-        Ok(Response::new(net::v0::SendChatToResponse {}))
+        let res = self.request("sendChatTo", request).await?;
+        Ok(Response::new(res))
     }
 
     async fn send_chat(
         &self,
         request: Request<net::v0::SendChatRequest>,
     ) -> Result<Response<net::v0::SendChatResponse>, Status> {
-        self.request("sendChat", request).await?;
-        Ok(Response::new(net::v0::SendChatResponse {}))
+        let res = self.request("sendChat", request).await?;
+        Ok(Response::new(res))
     }
 
     async fn get_players(
         &self,
         request: Request<net::v0::GetPlayersRequest>,
     ) -> Result<Response<net::v0::GetPlayersResponse>, Status> {
-        let res: net::v0::GetPlayersResponse = self.request("getPlayers", request).await?;
+        let res = self.request("getPlayers", request).await?;
         Ok(Response::new(res))
     }
 
@@ -33,15 +33,15 @@ impl NetService for MissionRpc {
         &self,
         request: Request<net::v0::ForcePlayerSlotRequest>,
     ) -> Result<Response<net::v0::ForcePlayerSlotResponse>, Status> {
-        self.request("forcePlayerSlot", request).await?;
-        Ok(Response::new(net::v0::ForcePlayerSlotResponse {}))
+        let res = self.request("forcePlayerSlot", request).await?;
+        Ok(Response::new(res))
     }
 
     async fn kick_player(
         &self,
         request: Request<net::v0::KickPlayerRequest>,
     ) -> Result<Response<net::v0::KickPlayerResponse>, Status> {
-        let res: net::v0::KickPlayerResponse = self.request("kickPlayer", request).await?;
+        let res = self.request("kickPlayer", request).await?;
         Ok(Response::new(res))
     }
 }

--- a/src/rpc/timer.rs
+++ b/src/rpc/timer.rs
@@ -9,7 +9,7 @@ impl TimerService for MissionRpc {
         &self,
         request: Request<timer::v0::GetTimeRequest>,
     ) -> Result<Response<timer::v0::GetTimeResponse>, Status> {
-        let res: timer::v0::GetTimeResponse = self.request("getTime", request).await?;
+        let res = self.request("getTime", request).await?;
         Ok(Response::new(res))
     }
 
@@ -17,8 +17,7 @@ impl TimerService for MissionRpc {
         &self,
         request: Request<timer::v0::GetAbsoluteTimeRequest>,
     ) -> Result<Response<timer::v0::GetAbsoluteTimeResponse>, Status> {
-        let res: timer::v0::GetAbsoluteTimeResponse =
-            self.request("getAbsoluteTime", request).await?;
+        let res = self.request("getAbsoluteTime", request).await?;
         Ok(Response::new(res))
     }
 
@@ -26,7 +25,7 @@ impl TimerService for MissionRpc {
         &self,
         request: Request<timer::v0::GetTimeZeroRequest>,
     ) -> Result<Response<timer::v0::GetTimeZeroResponse>, Status> {
-        let res: timer::v0::GetTimeZeroResponse = self.request("getTimeZero", request).await?;
+        let res = self.request("getTimeZero", request).await?;
         Ok(Response::new(res))
     }
 }

--- a/src/rpc/trigger.rs
+++ b/src/rpc/trigger.rs
@@ -9,7 +9,7 @@ impl TriggerService for MissionRpc {
         &self,
         request: Request<trigger::v0::OutTextRequest>,
     ) -> Result<Response<trigger::v0::OutTextResponse>, Status> {
-        self.notification("outText", request).await?;
+        self.request("outText", request).await?;
         Ok(Response::new(trigger::v0::OutTextResponse {}))
     }
 
@@ -17,7 +17,7 @@ impl TriggerService for MissionRpc {
         &self,
         request: Request<trigger::v0::OutTextForCoalitionRequest>,
     ) -> Result<Response<trigger::v0::OutTextForCoalitionResponse>, Status> {
-        self.notification("outTextForCoalition", request).await?;
+        self.request("outTextForCoalition", request).await?;
         Ok(Response::new(trigger::v0::OutTextForCoalitionResponse {}))
     }
 
@@ -25,7 +25,7 @@ impl TriggerService for MissionRpc {
         &self,
         request: Request<trigger::v0::OutTextForGroupRequest>,
     ) -> Result<Response<trigger::v0::OutTextForGroupResponse>, Status> {
-        self.notification("outTextForGroup", request).await?;
+        self.request("outTextForGroup", request).await?;
         Ok(Response::new(trigger::v0::OutTextForGroupResponse {}))
     }
 
@@ -41,7 +41,7 @@ impl TriggerService for MissionRpc {
         &self,
         request: Request<trigger::v0::SetUserFlagRequest>,
     ) -> Result<Response<trigger::v0::SetUserFlagResponse>, Status> {
-        self.notification("setUserFlag", request).await?;
+        self.request("setUserFlag", request).await?;
         Ok(Response::new(trigger::v0::SetUserFlagResponse {}))
     }
 
@@ -74,7 +74,7 @@ impl TriggerService for MissionRpc {
         &self,
         request: Request<trigger::v0::RemoveMarkRequest>,
     ) -> Result<Response<trigger::v0::RemoveMarkResponse>, Status> {
-        self.notification("removeMark", request).await?;
+        self.request("removeMark", request).await?;
         Ok(Response::new(trigger::v0::RemoveMarkResponse {}))
     }
 
@@ -82,7 +82,7 @@ impl TriggerService for MissionRpc {
         &self,
         request: Request<trigger::v0::ExplosionRequest>,
     ) -> Result<Response<trigger::v0::ExplosionResponse>, Status> {
-        self.notification("explosion", request).await?;
+        self.request("explosion", request).await?;
         Ok(Response::new(trigger::v0::ExplosionResponse {}))
     }
 
@@ -90,7 +90,7 @@ impl TriggerService for MissionRpc {
         &self,
         request: Request<trigger::v0::SmokeRequest>,
     ) -> Result<Response<trigger::v0::SmokeResponse>, Status> {
-        self.notification("smoke", request).await?;
+        self.request("smoke", request).await?;
         Ok(Response::new(trigger::v0::SmokeResponse {}))
     }
 
@@ -98,7 +98,7 @@ impl TriggerService for MissionRpc {
         &self,
         request: Request<trigger::v0::IlluminationBombRequest>,
     ) -> Result<Response<trigger::v0::IlluminationBombResponse>, Status> {
-        self.notification("illuminationBomb", request).await?;
+        self.request("illuminationBomb", request).await?;
         Ok(Response::new(trigger::v0::IlluminationBombResponse {}))
     }
 
@@ -106,7 +106,7 @@ impl TriggerService for MissionRpc {
         &self,
         request: Request<trigger::v0::SignalFlareRequest>,
     ) -> Result<Response<trigger::v0::SignalFlareResponse>, Status> {
-        self.notification("signalFlare", request).await?;
+        self.request("signalFlare", request).await?;
         Ok(Response::new(trigger::v0::SignalFlareResponse {}))
     }
 }

--- a/src/rpc/trigger.rs
+++ b/src/rpc/trigger.rs
@@ -9,31 +9,31 @@ impl TriggerService for MissionRpc {
         &self,
         request: Request<trigger::v0::OutTextRequest>,
     ) -> Result<Response<trigger::v0::OutTextResponse>, Status> {
-        self.request("outText", request).await?;
-        Ok(Response::new(trigger::v0::OutTextResponse {}))
+        let res = self.request("outText", request).await?;
+        Ok(Response::new(res))
     }
 
     async fn out_text_for_coalition(
         &self,
         request: Request<trigger::v0::OutTextForCoalitionRequest>,
     ) -> Result<Response<trigger::v0::OutTextForCoalitionResponse>, Status> {
-        self.request("outTextForCoalition", request).await?;
-        Ok(Response::new(trigger::v0::OutTextForCoalitionResponse {}))
+        let res = self.request("outTextForCoalition", request).await?;
+        Ok(Response::new(res))
     }
 
     async fn out_text_for_group(
         &self,
         request: Request<trigger::v0::OutTextForGroupRequest>,
     ) -> Result<Response<trigger::v0::OutTextForGroupResponse>, Status> {
-        self.request("outTextForGroup", request).await?;
-        Ok(Response::new(trigger::v0::OutTextForGroupResponse {}))
+        let res = self.request("outTextForGroup", request).await?;
+        Ok(Response::new(res))
     }
 
     async fn get_user_flag(
         &self,
         request: Request<trigger::v0::GetUserFlagRequest>,
     ) -> Result<Response<trigger::v0::GetUserFlagResponse>, Status> {
-        let res: trigger::v0::GetUserFlagResponse = self.request("getUserFlag", request).await?;
+        let res = self.request("getUserFlag", request).await?;
         Ok(Response::new(res))
     }
 
@@ -41,15 +41,15 @@ impl TriggerService for MissionRpc {
         &self,
         request: Request<trigger::v0::SetUserFlagRequest>,
     ) -> Result<Response<trigger::v0::SetUserFlagResponse>, Status> {
-        self.request("setUserFlag", request).await?;
-        Ok(Response::new(trigger::v0::SetUserFlagResponse {}))
+        let res = self.request("setUserFlag", request).await?;
+        Ok(Response::new(res))
     }
 
     async fn mark_to_all(
         &self,
         request: Request<trigger::v0::MarkToAllRequest>,
     ) -> Result<Response<trigger::v0::MarkToAllResponse>, Status> {
-        let res: trigger::v0::MarkToAllResponse = self.request("markToAll", request).await?;
+        let res = self.request("markToAll", request).await?;
         Ok(Response::new(res))
     }
 
@@ -57,8 +57,7 @@ impl TriggerService for MissionRpc {
         &self,
         request: Request<trigger::v0::MarkToCoalitionRequest>,
     ) -> Result<Response<trigger::v0::MarkToCoalitionResponse>, Status> {
-        let res: trigger::v0::MarkToCoalitionResponse =
-            self.request("markToCoalition", request).await?;
+        let res = self.request("markToCoalition", request).await?;
         Ok(Response::new(res))
     }
 
@@ -66,7 +65,7 @@ impl TriggerService for MissionRpc {
         &self,
         request: Request<trigger::v0::MarkToGroupRequest>,
     ) -> Result<Response<trigger::v0::MarkToGroupResponse>, Status> {
-        let res: trigger::v0::MarkToGroupResponse = self.request("markToGroup", request).await?;
+        let res = self.request("markToGroup", request).await?;
         Ok(Response::new(res))
     }
 
@@ -74,39 +73,39 @@ impl TriggerService for MissionRpc {
         &self,
         request: Request<trigger::v0::RemoveMarkRequest>,
     ) -> Result<Response<trigger::v0::RemoveMarkResponse>, Status> {
-        self.request("removeMark", request).await?;
-        Ok(Response::new(trigger::v0::RemoveMarkResponse {}))
+        let res = self.request("removeMark", request).await?;
+        Ok(Response::new(res))
     }
 
     async fn explosion(
         &self,
         request: Request<trigger::v0::ExplosionRequest>,
     ) -> Result<Response<trigger::v0::ExplosionResponse>, Status> {
-        self.request("explosion", request).await?;
-        Ok(Response::new(trigger::v0::ExplosionResponse {}))
+        let res = self.request("explosion", request).await?;
+        Ok(Response::new(res))
     }
 
     async fn smoke(
         &self,
         request: Request<trigger::v0::SmokeRequest>,
     ) -> Result<Response<trigger::v0::SmokeResponse>, Status> {
-        self.request("smoke", request).await?;
-        Ok(Response::new(trigger::v0::SmokeResponse {}))
+        let res = self.request("smoke", request).await?;
+        Ok(Response::new(res))
     }
 
     async fn illumination_bomb(
         &self,
         request: Request<trigger::v0::IlluminationBombRequest>,
     ) -> Result<Response<trigger::v0::IlluminationBombResponse>, Status> {
-        self.request("illuminationBomb", request).await?;
-        Ok(Response::new(trigger::v0::IlluminationBombResponse {}))
+        let res = self.request("illuminationBomb", request).await?;
+        Ok(Response::new(res))
     }
 
     async fn signal_flare(
         &self,
         request: Request<trigger::v0::SignalFlareRequest>,
     ) -> Result<Response<trigger::v0::SignalFlareResponse>, Status> {
-        self.request("signalFlare", request).await?;
-        Ok(Response::new(trigger::v0::SignalFlareResponse {}))
+        let res = self.request("signalFlare", request).await?;
+        Ok(Response::new(res))
     }
 }

--- a/src/rpc/unit.rs
+++ b/src/rpc/unit.rs
@@ -12,7 +12,7 @@ impl UnitService for MissionRpc {
         &self,
         request: Request<unit::v0::GetRadarRequest>,
     ) -> Result<Response<unit::v0::GetRadarResponse>, Status> {
-        let res: unit::v0::GetRadarResponse = self.request("getRadar", request).await?;
+        let res = self.request("getRadar", request).await?;
         Ok(Response::new(res))
     }
 
@@ -20,7 +20,7 @@ impl UnitService for MissionRpc {
         &self,
         request: Request<unit::v0::GetPositionRequest>,
     ) -> Result<Response<unit::v0::GetPositionResponse>, Status> {
-        let res: unit::v0::GetPositionResponse = self.request("getUnitPosition", request).await?;
+        let res = self.request("getUnitPosition", request).await?;
         Ok(Response::new(res))
     }
 
@@ -28,8 +28,7 @@ impl UnitService for MissionRpc {
         &self,
         request: Request<unit::v0::GetPlayerNameRequest>,
     ) -> Result<Response<unit::v0::GetPlayerNameResponse>, Status> {
-        let res: unit::v0::GetPlayerNameResponse =
-            self.request("getUnitPlayerName", request).await?;
+        let res = self.request("getUnitPlayerName", request).await?;
         Ok(Response::new(res))
     }
 
@@ -37,8 +36,7 @@ impl UnitService for MissionRpc {
         &self,
         request: Request<unit::v0::GetDescriptorRequest>,
     ) -> Result<Response<unit::v0::GetDescriptorResponse>, Status> {
-        let res: unit::v0::GetDescriptorResponse =
-            self.request("getUnitDescriptor", request).await?;
+        let res = self.request("getUnitDescriptor", request).await?;
         Ok(Response::new(res))
     }
 
@@ -46,15 +44,15 @@ impl UnitService for MissionRpc {
         &self,
         request: Request<unit::v0::SetEmissionRequest>,
     ) -> Result<Response<unit::v0::SetEmissionResponse>, Status> {
-        self.request("setEmission", request).await?;
-        Ok(Response::new(unit::v0::SetEmissionResponse {}))
+        let res = self.request("setEmission", request).await?;
+        Ok(Response::new(res))
     }
 
     async fn get(
         &self,
         request: Request<unit::v0::GetRequest>,
     ) -> Result<Response<unit::v0::GetResponse>, Status> {
-        let res: unit::v0::GetResponse = self.request("getUnit", request).await?;
+        let res = self.request("getUnit", request).await?;
         Ok(Response::new(res))
     }
 

--- a/src/rpc/unit.rs
+++ b/src/rpc/unit.rs
@@ -46,7 +46,7 @@ impl UnitService for MissionRpc {
         &self,
         request: Request<unit::v0::SetEmissionRequest>,
     ) -> Result<Response<unit::v0::SetEmissionResponse>, Status> {
-        self.notification("setEmission", request).await?;
+        self.request("setEmission", request).await?;
         Ok(Response::new(unit::v0::SetEmissionResponse {}))
     }
 

--- a/src/rpc/world.rs
+++ b/src/rpc/world.rs
@@ -9,7 +9,7 @@ impl WorldService for MissionRpc {
         &self,
         request: Request<world::v0::GetAirbasesRequest>,
     ) -> Result<Response<world::v0::GetAirbasesResponse>, Status> {
-        let res: world::v0::GetAirbasesResponse = self.request("getAirbases", request).await?;
+        let res = self.request("getAirbases", request).await?;
         Ok(Response::new(res))
     }
 
@@ -17,7 +17,7 @@ impl WorldService for MissionRpc {
         &self,
         request: Request<world::v0::GetMarkPanelsRequest>,
     ) -> Result<Response<world::v0::GetMarkPanelsResponse>, Status> {
-        let res: world::v0::GetMarkPanelsResponse = self.request("getMarkPanels", request).await?;
+        let res = self.request("getMarkPanels", request).await?;
         Ok(Response::new(res))
     }
 }


### PR DESCRIPTION
IPS `request`s will be used instead. This ensures that errors are
handled everywhere (they where ignored for notifications).

Result of the discussion in https://github.com/DCS-gRPC/rust-server/pull/134#discussion_r852141047