### PR TITLE
Add `MarkupToAll` and `MarkupToCoalition` APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `OutTextForUnit` API
+- `MarkupToAll` API
+- `MarkupToCoalition` API
 
 ## [0.5.0] - 2022-04-19
 ### Added

--- a/STATUS.md
+++ b/STATUS.md
@@ -157,7 +157,8 @@ should use their independent logging and tracing functions.
 - [x] `markToCoalition`
 - [x] `markToGroup`
 - [x] `removeMark`
-- [ ] `markupToAll`
+- [x] `markupToAll`
+- [x] `markupToCoalition`
 - [ ] `lineToAll`
 - [ ] `circleToAll`
 - [ ] `rectToAll`

--- a/lua/DCS-gRPC/methods/trigger.lua
+++ b/lua/DCS-gRPC/methods/trigger.lua
@@ -103,6 +103,52 @@ GRPC.methods.removeMark = function(params)
   return GRPC.success({})
 end
 
+GRPC.methods.markupToAll = function(params)
+  local idx = getMarkId()
+  local coalition = params.coalition or -1
+
+   -- Number of points is variable so we need to make a table that we unpack
+   -- later and add all parameters after the points into it as well
+  local packedParams = {}
+  for _, value in ipairs(params.points) do
+    table.insert(packedParams, coord.LLtoLO(value.lat, value.lon, value.alt))
+  end
+
+  table.insert(packedParams, {
+    params.borderColor.red,
+    params.borderColor.green,
+    params.borderColor.blue,
+    params.borderColor.alpha
+  })
+  table.insert(packedParams, {
+    params.fillColor.red,
+    params.fillColor.green,
+    params.fillColor.blue,
+    params.fillColor.alpha
+  })
+  table.insert(packedParams, params.lineType)
+  table.insert(packedParams, params.readOnly)
+  table.insert(packedParams, params.message)
+
+  trigger.action.markupToAll(params.shape, coalition, idx, unpack(packedParams))
+
+  return GRPC.success({
+    id = idx
+  })
+end
+
+GRPC.methods.markupToCoalition = function(params)
+  if params.coalition == 0 then
+    return GRPC.errorInvalidArgument("a specific coalition must be chosen")
+  end
+
+  params.coalition = params.coalition - 1 -- Decrement for non zero-indexed gRPC enum
+
+  return GRPC.methods.markupToAll(params)
+
+end
+
+
 GRPC.methods.explosion = function(params)
   local point = coord.LLtoLO(params.position.lat, params.position.lon, params.position.alt)
 

--- a/protos/dcs/trigger/v0/trigger.proto
+++ b/protos/dcs/trigger/v0/trigger.proto
@@ -37,6 +37,14 @@ service TriggerService {
   // https://wiki.hoggitworld.com/view/DCS_func_markToGroup
   rpc MarkToGroup(MarkToGroupRequest) returns (MarkToGroupResponse) {}
 
+  // https://wiki.hoggitworld.com/view/DCS_func_markupToAll
+  rpc MarkupToAll(MarkupToAllRequest) returns (MarkupToAllResponse) {}
+
+  // Uses markupToAll under the hood but enforces a coalition to be specified
+  // https://wiki.hoggitworld.com/view/DCS_func_markupToAll
+  rpc MarkupToCoalition(MarkupToCoalitionRequest)
+      returns (MarkupToCoalitionResponse) {}
+
   // https://wiki.hoggitworld.com/view/DCS_func_removeMark
   rpc RemoveMark(RemoveMarkRequest) returns (RemoveMarkResponse) {}
 
@@ -207,4 +215,65 @@ message SignalFlareRequest {
 }
 
 message SignalFlareResponse {
+}
+
+enum LineType {
+  // protolint:disable:next ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH
+  LINE_TYPE_NO_LINE = 0;
+  LINE_TYPE_SOLID = 1;
+  LINE_TYPE_DASHED = 2;
+  LINE_TYPE_DOTTED = 3;
+  LINE_TYPE_DOT_DASH = 4;
+  LINE_TYPE_LONG_DASH = 5;
+  LINE_TYPE_TWO_DASH = 6;
+}
+
+// Represents an RGBA color but instead of using 0-255 as the color
+// values it uses 0 to 1. A red color with 50% transparency would be
+// RGBA of 1, 0, 0, 0.5
+message Color {
+  double red = 1;
+  double green = 2;
+  double blue = 3;
+  double alpha = 4;
+}
+
+enum Shape {
+  SHAPE_UNSPECIFIED = 0;
+  SHAPE_LINE = 1;
+  SHAPE_CIRCLE = 2;
+  SHAPE_RECT = 3;
+  SHAPE_ARROW = 4;
+  SHAPE_TEXT = 5;
+  SHAPE_QUAD = 6;
+  SHAPE_FREEFORM = 7;
+}
+
+message MarkupToAllRequest {
+  Shape shape = 1;
+  repeated dcs.common.v0.Position points = 2;
+  Color border_color = 3;
+  Color fill_color = 4;
+  LineType line_type = 5;
+  bool read_only = 6;
+  string message = 7;
+}
+
+message MarkupToAllResponse {
+  uint32 id = 1;
+}
+
+message MarkupToCoalitionRequest {
+  Shape shape = 1;
+  dcs.common.v0.Coalition coalition = 2;
+  repeated dcs.common.v0.Position points = 3;
+  Color border_color = 4;
+  Color fill_color = 5;
+  LineType line_type = 6;
+  bool read_only = 7;
+  string message = 8;
+}
+
+message MarkupToCoalitionResponse {
+  uint32 id = 1;
 }

--- a/src/rpc/trigger.rs
+++ b/src/rpc/trigger.rs
@@ -85,6 +85,22 @@ impl TriggerService for MissionRpc {
         Ok(Response::new(res))
     }
 
+    async fn markup_to_all(
+        &self,
+        request: Request<trigger::v0::MarkupToAllRequest>,
+    ) -> Result<Response<trigger::v0::MarkupToAllResponse>, Status> {
+        let res = self.request("markupToAll", request).await?;
+        Ok(Response::new(res))
+    }
+
+    async fn markup_to_coalition(
+        &self,
+        request: Request<trigger::v0::MarkupToCoalitionRequest>,
+    ) -> Result<Response<trigger::v0::MarkupToCoalitionResponse>, Status> {
+        let res = self.request("markupToCoalition", request).await?;
+        Ok(Response::new(res))
+    }
+
     async fn explosion(
         &self,
         request: Request<trigger::v0::ExplosionRequest>,


### PR DESCRIPTION
Although there is no `MarkupToCoalition` in the scripting environment;
we will add a gRPC level API for one to keep in line with the `MarkTo*`
APIs. There is no way to do a `MarkupToGroup` so we are not implementing
it.