### PR TITLE
Add `GetTheatre` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `OutTextForUnit` API
 - `MarkupToAll` API
 - `MarkupToCoalition` API
+- `GetTheatre` API
 
 ## [0.5.0] - 2022-04-19
 ### Added

--- a/STATUS.md
+++ b/STATUS.md
@@ -187,13 +187,14 @@ should use their independent logging and tracing functions.
 ### Voice Chat
 - [ ] `createRoom`
 
-### DCS Singleton
+### DCS Singleton (DCS-gRPC WorldService)
 - [ ] `addEventHandler` (TODO: Should implement? Probably not)
 - [ ] `removeEventHandler`
 - [ ] `getPlayer`
 - [x] `getAirbases`
 - [ ] `searchObjects`
 - [x] `getMarkPanels`
+- [x] `getTheatre` (DCS-gRPC method. Calls env.mission.theatre internally)
 
 ### DCS Events
 - [x] `S_EVENT_INVALID`

--- a/lua/DCS-gRPC/methods/world.lua
+++ b/lua/DCS-gRPC/methods/world.lua
@@ -38,3 +38,7 @@ GRPC.methods.getMarkPanels = function()
 
   return GRPC.success({markPanels = result})
 end
+
+GRPC.methods.getTheatre = function()
+  return GRPC.success({theatre = env.mission.theatre})
+end

--- a/protos/dcs/world/v0/world.proto
+++ b/protos/dcs/world/v0/world.proto
@@ -11,6 +11,9 @@ service WorldService {
 
   // https://wiki.hoggitworld.com/view/DCS_func_getMarkPanels
   rpc GetMarkPanels(GetMarkPanelsRequest) returns (GetMarkPanelsResponse) {}
+
+  // Returns the theatre (Map name) of the mission
+  rpc GetTheatre(GetTheatreRequest) returns (GetTheatreResponse) {}
 }
 
 message GetAirbasesRequest {
@@ -26,4 +29,11 @@ message GetMarkPanelsRequest {
 
 message GetMarkPanelsResponse {
   repeated dcs.common.v0.MarkPanel mark_panels = 1;
+}
+
+message GetTheatreRequest {
+}
+
+message GetTheatreResponse {
+  string theatre = 1;
 }

--- a/src/rpc/world.rs
+++ b/src/rpc/world.rs
@@ -20,4 +20,12 @@ impl WorldService for MissionRpc {
         let res = self.request("getMarkPanels", request).await?;
         Ok(Response::new(res))
     }
+
+    async fn get_theatre(
+        &self,
+        request: Request<world::v0::GetTheatreRequest>,
+    ) -> Result<Response<world::v0::GetTheatreResponse>, Status> {
+        let res = self.request("getTheatre", request).await?;
+        Ok(Response::new(res))
+    }
 }


### PR DESCRIPTION
Returns the theatre (map name) as a string. I chose to do it this way
instead of an enum because it was simpler and would mean we don't need
to update it when new maps come out.

I stuck with the UK spelling since that is what is used by ED and pure British
spelling is _obviously_ superior to debased US spelling (Rule Britannia etc).