### PR TITLE
Add Static Objects API

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -16,6 +16,7 @@ read_globals = {
   "lfs",
   "log",
   "Object",
+  "StaticObject",
   "timer",
   "trigger",
   "Unit",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `OutTextForUnit` API
+- `AddStaticObject` API (for standard static objects)
+- `AddLinkedStatic` API (for statics linked to units such as ships)
 - `MarkupToAll` API
 - `MarkupToCoalition` API
 - `GetTheatre` API

--- a/STATUS.md
+++ b/STATUS.md
@@ -39,7 +39,7 @@ future; pull requests are welcomed for expanding the API equivalency.
     - [ ] Waypoints
     - [ ] Tasks
     - [ ] Loadout
-- [ ] `addStaticObject`
+- [x] `addStaticObject`
 - [x] `getGroups`
 - [ ] `getStaticObjects`
 - [x] `getAirbases`

--- a/protos/dcs/coalition/v0/coalition.proto
+++ b/protos/dcs/coalition/v0/coalition.proto
@@ -9,6 +9,16 @@ service CoalitionService {
   // https://wiki.hoggitworld.com/view/DCS_func_addGroup
   rpc AddGroup(AddGroupRequest) returns (AddGroupResponse) {}
 
+  // Focussed on statics (linked statics - see `AddLinkedStatic`)
+  // https://wiki.hoggitworld.com/view/DCS_func_addStaticObject
+  rpc AddStaticObject(AddStaticObjectRequest)
+      returns (AddStaticObjectResponse) {}
+
+  // Focussed on properties relevant to linked static objects
+  // https://wiki.hoggitworld.com/view/DCS_func_addStaticObject
+  rpc AddLinkedStatic(AddLinkedStaticRequest)
+      returns (AddLinkedStaticResponse) {}
+
   // https://wiki.hoggitworld.com/view/DCS_func_getGroups
   rpc GetGroups(GetGroupsRequest) returns (GetGroupsResponse) {}
 
@@ -119,6 +129,59 @@ message AddGroupRequest {
 
 message AddGroupResponse {
   dcs.common.v0.Group group = 1;
+}
+
+message AddStaticObjectRequest {
+  // the name of the static; must be unique or would destroy previous object
+  string name = 1;
+  // country the unit belongs to
+  dcs.common.v0.Country country = 2;
+  // type of the static object (e.g. "Farm A", "AS32-31A")
+  string type = 3;
+  // string name of the livery for the aircraft
+  string livery = 4;
+  // boolean for whether or not the object will appear as a wreck
+  bool dead = 5;
+  // number value for the "score" of the object when it is killed
+  optional uint32 rate = 6;
+
+  double heading = 7;
+  dcs.common.v0.Position position = 8;
+  // cargo mass in kilograms
+  uint32 cargo_mass = 9;
+}
+
+message AddStaticObjectResponse {
+  string name = 1;
+}
+
+message AddLinkedStaticRequest {
+  // the name of the static; must be unique or would destroy previous object
+  string name = 1;
+  // country the unit belongs to
+  dcs.common.v0.Country country = 2;
+  // type of the static object (e.g. "Farm A", "AS32-31A")
+  string type = 3;
+  // string name of the livery for the aircraft
+  string livery = 4;
+  // boolean for whether or not the object will appear as a wreck
+  bool dead = 5;
+  // number value for the "score" of the object when it is killed
+  optional uint32 rate = 6;
+  // the name of the unit to offset from
+  string unit = 7;
+  // the angle to relative to the linked unit, in a clockwise direction.
+  // negative values are anti-clockwise
+  double angle = 8;
+  // x offset from linked unit center (positive is forward; negative is aft)
+  double x = 9;
+  // y offset from linked unit center (positive is starboard-side;
+  // negative is port-side)
+  double y = 10;
+}
+
+message AddLinkedStaticResponse {
+  string name = 1;
 }
 
 message GetGroupsRequest {

--- a/src/rpc/coalition.rs
+++ b/src/rpc/coalition.rs
@@ -13,6 +13,22 @@ impl CoalitionService for MissionRpc {
         Ok(Response::new(res))
     }
 
+    async fn add_static_object(
+        &self,
+        request: Request<coalition::v0::AddStaticObjectRequest>,
+    ) -> Result<Response<coalition::v0::AddStaticObjectResponse>, Status> {
+        let res = self.request("addStaticObject", request).await?;
+        Ok(Response::new(res))
+    }
+
+    async fn add_linked_static(
+        &self,
+        request: Request<coalition::v0::AddLinkedStaticRequest>,
+    ) -> Result<Response<coalition::v0::AddLinkedStaticResponse>, Status> {
+        let res = self.request("addLinkedStatic", request).await?;
+        Ok(Response::new(res))
+    }
+
     async fn get_groups(
         &self,
         request: Request<coalition::v0::GetGroupsRequest>,


### PR DESCRIPTION
Implementation of `addStaticObject` via the gRPC interface.

The cargo type is free text so to avoid the requirements of DCS-gRPC
installations and clients to be coupled to any DCS updates / new units /
 renames

* Static positioning
* Linked unit
* Cargo handling