### PR TITLE
Prepend Search Path

### DIFF
--- a/lua/DCS-gRPC/grpc-hook.lua
+++ b/lua/DCS-gRPC/grpc-hook.lua
@@ -4,7 +4,7 @@ local function load()
 
   -- Let DCS know where to find the DLLs
   if not string.find(package.cpath, GRPC.dllPath) then
-    package.cpath = package.cpath .. [[;]] .. GRPC.dllPath .. [[?.dll;]]
+    package.cpath =  GRPC.dllPath .. [[?.dll;]] .. package.cpath
   end
 
   local ok, grpc = pcall(require, "dcs_grpc_hot_reload")

--- a/lua/DCS-gRPC/grpc-mission.lua
+++ b/lua/DCS-gRPC/grpc-mission.lua
@@ -29,7 +29,7 @@ end
 
 -- Let DCS know where to find the DLLs
 if not string.find(package.cpath, GRPC.dllPath) then
-  package.cpath = package.cpath .. [[;]] .. GRPC.dllPath .. [[?.dll;]]
+  package.cpath =  GRPC.dllPath .. [[?.dll;]] .. package.cpath
 end
 
 -- Load DLL before `require` gets sanitized.


### PR DESCRIPTION
Reduces the number of search entries for search paths.

Not all modules would append a semi-colon (`;`) for the path at the end.
 Inserting the gRPC search path in the beginning would eliminate a
 potential blank search path `somePath;;pathForGRPC;` and instead make
 the brief search path of `pathForGRPC;someOtherPath`.