### PR TITLE
Fix eval json encoding limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,11 +228,6 @@ return Group.getByName('Aerial-1'):getName()
 
 The REPL is also available in the release and can be run by running `Tools/DCS-gRPC/repl.exe`
 
-Please note that there are some circumstances where results will not return properly:
-
-* Lua tables that do not have a 0 index will cause an error and return nothing
-* Lua tables with a mix of integer and string keys will return only the integer keys.
-
 ### Contributions
 
 This repository is powered by GitHub Actions for the Continuous Integration (CI) services. The same CI checks would be

--- a/lua/DCS-gRPC/methods/custom.lua
+++ b/lua/DCS-gRPC/methods/custom.lua
@@ -29,5 +29,5 @@ GRPC.methods.missionEval = function(params)
         return GRPC.error("Failed to execute Lua code: "..result)
     end
 
-    return GRPC.success(result)
+    return GRPC.success(net.lua2json(result))
 end

--- a/lua/DCS-gRPC/methods/hook.lua
+++ b/lua/DCS-gRPC/methods/hook.lua
@@ -47,7 +47,7 @@ GRPC.methods.hookEval = function(params)
     return GRPC.error("Failed to execute Lua code: "..result)
   end
 
-  return GRPC.success(result)
+  return GRPC.success(net.lua2json(result))
 end
 
 GRPC.methods.isMultiplayer = function()

--- a/src/rpc/custom.rs
+++ b/src/rpc/custom.rs
@@ -47,10 +47,7 @@ impl CustomService for MissionRpc {
             return Err(Status::permission_denied("eval operation is disabled"));
         }
 
-        let json: serde_json::Value = self.request("missionEval", request).await?;
-        let json = serde_json::to_string(&json).map_err(|err| {
-            Status::internal(format!("failed to deserialize eval result: {}", err))
-        })?;
+        let json: String = self.request("missionEval", request).await?;
         Ok(Response::new(custom::v0::EvalResponse { json }))
     }
 

--- a/src/rpc/hook.rs
+++ b/src/rpc/hook.rs
@@ -61,10 +61,7 @@ impl HookService for HookRpc {
             return Err(Status::permission_denied("eval operation is disabled"));
         }
 
-        let json: serde_json::Value = self.request("hookEval", request).await?;
-        let json = serde_json::to_string(&json).map_err(|err| {
-            Status::internal(format!("failed to deserialize eval result: {}", err))
-        })?;
+        let json: String = self.request("hookEval", request).await?;
         Ok(Response::new(hook::v0::EvalResponse { json }))
     }
 


### PR DESCRIPTION
Here is a possible fix for https://github.com/DCS-gRPC/rust-server/issues/137. It's fixed by using `net.lua2json` instead of doing the Lua->JSON conversion in Rust.

As an alternative, I might also be able to update the Rust Lua->JSON conversion to handle the cases mentioned in #137, but simply using `lua2json` is a way easier solution.
