### PR TITLE
Get Static Objects API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `OutTextForUnit` API
+- `GetStaticObjects` API
 - `AddStaticObject` API (for standard static objects)
 - `AddLinkedStatic` API (for statics linked to units such as ships)
 - `MarkupToAll` API

--- a/STATUS.md
+++ b/STATUS.md
@@ -41,7 +41,7 @@ future; pull requests are welcomed for expanding the API equivalency.
     - [ ] Loadout
 - [x] `addStaticObject`
 - [x] `getGroups`
-- [ ] `getStaticObjects`
+- [x] `getStaticObjects`
 - [x] `getAirbases`
 - [x] `getPlayers`
 - [ ] `getServiceProviders`

--- a/lua/DCS-gRPC/methods/coalitions.lua
+++ b/lua/DCS-gRPC/methods/coalitions.lua
@@ -120,6 +120,21 @@ GRPC.methods.addGroup = function(params)
   return GRPC.success({group = GRPC.exporters.group(Group.getByName(template.name))})
 end
 
+GRPC.methods.getStaticObjects = function(params)
+  local result = {}
+  for _, coalitionId in pairs(coalition.side) do
+    if params.coalition == 0 or params.coalition - 1 == coalitionId then -- Decrement for non zero-indexed gRPC enum
+      local staticObjects = coalition.getStaticObjects(coalitionId)
+
+      for _, staticObject in ipairs(staticObjects) do
+        table.insert(result, GRPC.exporters.static(staticObject))
+      end
+    end
+  end
+
+  return GRPC.success({statics = result})
+end
+
 GRPC.methods.addStaticObject = function(params)
   if params.name == nil or params.name == "" then
     return GRPC.errorInvalidArgument("name not supplied")

--- a/protos/dcs/coalition/v0/coalition.proto
+++ b/protos/dcs/coalition/v0/coalition.proto
@@ -9,6 +9,10 @@ service CoalitionService {
   // https://wiki.hoggitworld.com/view/DCS_func_addGroup
   rpc AddGroup(AddGroupRequest) returns (AddGroupResponse) {}
 
+  // https://wiki.hoggitworld.com/view/DCS_func_getStaticObjects
+  rpc GetStaticObjects(GetStaticObjectsRequest)
+      returns (GetStaticObjectsResponse) {}
+
   // Focussed on statics (linked statics - see `AddLinkedStatic`)
   // https://wiki.hoggitworld.com/view/DCS_func_addStaticObject
   rpc AddStaticObject(AddStaticObjectRequest)
@@ -129,6 +133,16 @@ message AddGroupRequest {
 
 message AddGroupResponse {
   dcs.common.v0.Group group = 1;
+}
+
+message GetStaticObjectsRequest {
+  // the coalition which the statics belong to
+  dcs.common.v0.Coalition coalition = 1;
+}
+
+message GetStaticObjectsResponse {
+  // the list of statics
+  repeated dcs.common.v0.Static statics = 1;
 }
 
 message AddStaticObjectRequest {

--- a/src/rpc/coalition.rs
+++ b/src/rpc/coalition.rs
@@ -13,6 +13,14 @@ impl CoalitionService for MissionRpc {
         Ok(Response::new(res))
     }
 
+    async fn get_static_objects(
+        &self,
+        request: Request<coalition::v0::GetStaticObjectsRequest>,
+    ) -> Result<Response<coalition::v0::GetStaticObjectsResponse>, Status> {
+        let res = self.request("getStaticObjects", request).await?;
+        Ok(Response::new(res))
+    }
+
     async fn add_static_object(
         &self,
         request: Request<coalition::v0::AddStaticObjectRequest>,


### PR DESCRIPTION
Retrieves all the statics populated to a coalition (or all!)

Tracks positions of statics attached to units and/or cargo as expected.