### PR TITLE
Add `GetUnitType` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MarkupToAll` API
 - `MarkupToCoalition` API
 - `GetTheatre` API
+- `GetUnitType` API
 
 ## [0.5.0] - 2022-04-19
 ### Added

--- a/STATUS.md
+++ b/STATUS.md
@@ -276,7 +276,7 @@ should use their independent logging and tracing functions.
 - [x] `getMissionFilename`
 - [ ] `getMissionResult`
 - [ ] `getUnitProperty`
-- [ ] `getUnitType`
+- [x] `getUnitType`
 - [ ] `getUnitTypeAttribute`
 - [ ] `writeDebriefing`
 - [ ] `makeScreenShot`

--- a/lua/DCS-gRPC/methods/hook.lua
+++ b/lua/DCS-gRPC/methods/hook.lua
@@ -92,3 +92,14 @@ GRPC.methods.getBannedPlayers = function()
 
   return GRPC.success({bans = result})
 end
+
+GRPC.methods.getUnitType = function(params)
+  -- https://wiki.hoggitworld.com/view/DCS_func_getUnitType
+  local unit_type = DCS.getUnitType(params.id)
+  -- getUnitType returns an empty string if the unit doesn't exist, ensure we catch eventual nils too
+  if unit_type == nil or unit_type == "" then
+    return GRPC.errorNotFound("unit `" .. tostring(params.id) .. "` does not exist")
+  end
+
+  return GRPC.success({type = unit_type})
+end

--- a/protos/dcs/hook/v0/hook.proto
+++ b/protos/dcs/hook/v0/hook.proto
@@ -47,6 +47,9 @@ service HookService {
   // Get a list of all the banned players
   rpc GetBannedPlayers(GetBannedPlayersRequest)
     returns (GetBannedPlayersResponse) {}
+
+  // https://wiki.hoggitworld.com/view/DCS_func_getUnitType
+  rpc GetUnitType(GetUnitTypeRequest) returns (GetUnitTypeResponse) {}
 }
 
 message GetMissionNameRequest {
@@ -162,4 +165,14 @@ message BanDetails {
   uint64 banned_from = 5;
   // When the ban will expire in unixtime
   uint64 banned_until = 6;
+}
+
+message GetUnitTypeRequest {
+  // The slot or unit ID of the unit to retrieve the type of
+  string id = 1;
+}
+
+message GetUnitTypeResponse {
+  // Type of unit (e.g. "F-14B")
+  string type = 1;
 }

--- a/src/rpc/hook.rs
+++ b/src/rpc/hook.rs
@@ -112,4 +112,12 @@ impl HookService for HookRpc {
         let res = self.request("getBannedPlayers", request).await?;
         Ok(Response::new(res))
     }
+
+    async fn get_unit_type(
+        &self,
+        request: Request<hook::v0::GetUnitTypeRequest>,
+    ) -> Result<Response<hook::v0::GetUnitTypeResponse>, Status> {
+        let res = self.request("getUnitType", request).await?;
+        Ok(Response::new(res))
+    }
 }


### PR DESCRIPTION
Tiny PR to add [`DCS.GetUnitType`](https://wiki.hoggitworld.com/view/DCS_func_getUnitType) 🙂 

As discussed via Discord, I originally has this located as under the `UnitService`, where I would instinctively look for it, but since it uses the `DCS` singleton, we have to have it reside within `hooks.lua`. I'm indifferent though about where to keep it - it's in `HookService` now to be consistent with the rest of the hook functions, but I can also move it to `UnitService` if that'd be preferred.