### PR TITLE
Update Lua module methods to never return errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GetTheatre` API
 - `GetUnitType` API
 
+### Changed
+- Improved reliability of error handling.
+
 ## [0.5.0] - 2022-04-19
 ### Added
 - `GetMissionFilename` API

--- a/src/hot_reload.rs
+++ b/src/hot_reload.rs
@@ -1,8 +1,8 @@
-use std::path::PathBuf;
 ///! This module is a wrapper around all exposed Lua methods which are forwarded to a dynamically
 ///! loaded dcs_grpc.dll. Upon calling the `stop()` method, the library is unloaded, and re-
 ///! loaded during the next `start()` call.
-use std::sync::{Arc, RwLock};
+use std::path::PathBuf;
+use std::sync::RwLock;
 
 use crate::Config;
 use libloading::{Library, Symbol};
@@ -12,109 +12,112 @@ use once_cell::sync::Lazy;
 
 static LIBRARY: Lazy<RwLock<Option<Library>>> = Lazy::new(|| RwLock::new(None));
 
-pub fn start(lua: &Lua, config: Config) -> LuaResult<()> {
+pub fn start(lua: &Lua, config: Config) {
     let lib_path = {
         let mut lib_path = PathBuf::from(&config.dll_path);
         lib_path.push("dcs_grpc.dll");
         lib_path
     };
 
-    let new_lib = unsafe { Library::new(lib_path) }.map_err(|err| {
-        log::error!("Load: {}", err);
-        mlua::Error::ExternalError(Arc::new(err))
-    })?;
+    let new_lib = match unsafe { Library::new(lib_path) } {
+        Ok(new_lib) => new_lib,
+        Err(err) => {
+            log::error!("Failed to load `dcs_grpc.dll`: {}", err);
+            return;
+        }
+    };
     let mut lib = LIBRARY.write().unwrap();
     let lib = lib.get_or_insert(new_lib);
 
-    let f: Symbol<fn(lua: &Lua, config: Config) -> LuaResult<()>> = unsafe {
-        lib.get(b"start")
-            .map_err(|err| mlua::Error::ExternalError(Arc::new(err)))?
-    };
-    let result = f(lua, config);
-
-    result
+    match unsafe { lib.get::<Symbol<fn(lua: &Lua, config: Config)>>(b"start") } {
+        Ok(f) => f(lua, config),
+        Err(err) => {
+            log::error!("Failed to get `start` method: {}", err);
+        }
+    }
 }
 
-pub fn stop(lua: &Lua, arg: ()) -> LuaResult<()> {
+pub fn stop(lua: &Lua, arg: ()) {
     if let Some(lib) = LIBRARY.write().unwrap().take() {
-        let f: Symbol<fn(lua: &Lua, arg: ()) -> LuaResult<()>> = unsafe {
-            lib.get(b"stop")
-                .map_err(|err| mlua::Error::ExternalError(Arc::new(err)))?
-        };
-        f(lua, arg)
-    } else {
-        Ok(())
+        match unsafe { lib.get::<Symbol<fn(lua: &Lua, arg: ())>>(b"stop") } {
+            Ok(f) => f(lua, arg),
+            Err(err) => {
+                log::error!("Failed to get `stop` method: {}", err);
+            }
+        }
     }
 }
 
-pub fn next(lua: &Lua, arg: (i32, Function)) -> LuaResult<bool> {
+pub fn next(lua: &Lua, arg: (i32, Function)) -> bool {
     if let Some(ref lib) = *LIBRARY.read().unwrap() {
-        let f: Symbol<fn(lua: &Lua, arg: (i32, Function)) -> LuaResult<bool>> = unsafe {
-            lib.get(b"next")
-                .map_err(|err| mlua::Error::ExternalError(Arc::new(err)))?
-        };
-        f(lua, arg)
+        match unsafe { lib.get::<Symbol<fn(lua: &Lua, arg: (i32, Function)) -> bool>>(b"next") } {
+            Ok(f) => f(lua, arg),
+            Err(err) => {
+                log::error!("Failed to get `next` method: {}", err);
+                return false;
+            }
+        }
     } else {
-        Ok(false)
+        false
     }
 }
 
-pub fn event(lua: &Lua, event: Value) -> LuaResult<()> {
+pub fn event(lua: &Lua, event: Value) {
     if let Some(ref lib) = *LIBRARY.read().unwrap() {
-        let f: Symbol<fn(lua: &Lua, event: Value) -> LuaResult<()>> = unsafe {
-            lib.get(b"event")
-                .map_err(|err| mlua::Error::ExternalError(Arc::new(err)))?
-        };
-        f(lua, event)
-    } else {
-        Ok(())
+        match unsafe { lib.get::<Symbol<fn(lua: &Lua, event: Value)>>(b"event") } {
+            Ok(f) => f(lua, event),
+            Err(err) => {
+                log::error!("Failed to get `event` method: {}", err);
+                return;
+            }
+        }
     }
 }
 
-pub fn log_error(lua: &Lua, err: String) -> LuaResult<()> {
+pub fn log_error(lua: &Lua, err: String) {
     if let Some(ref lib) = *LIBRARY.read().unwrap() {
-        let f: Symbol<fn(lua: &Lua, err: String) -> LuaResult<()>> = unsafe {
-            lib.get(b"log_error")
-                .map_err(|err| mlua::Error::ExternalError(Arc::new(err)))?
-        };
-        f(lua, err)
-    } else {
-        Ok(())
+        match unsafe { lib.get::<Symbol<fn(lua: &Lua, err: String)>>(b"log_error") } {
+            Ok(f) => f(lua, err),
+            Err(err) => {
+                log::error!("Failed to get `log_error` method: {}", err);
+                return;
+            }
+        }
     }
 }
 
-pub fn log_warning(lua: &Lua, err: String) -> LuaResult<()> {
+pub fn log_warning(lua: &Lua, msg: String) {
     if let Some(ref lib) = *LIBRARY.read().unwrap() {
-        let f: Symbol<fn(lua: &Lua, err: String) -> LuaResult<()>> = unsafe {
-            lib.get(b"log_warning")
-                .map_err(|err| mlua::Error::ExternalError(Arc::new(err)))?
-        };
-        f(lua, err)
-    } else {
-        Ok(())
+        match unsafe { lib.get::<Symbol<fn(lua: &Lua, err: String)>>(b"log_warning") } {
+            Ok(f) => f(lua, msg),
+            Err(err) => {
+                log::error!("Failed to get `log_warning` method: {}", err);
+                return;
+            }
+        }
     }
 }
 
-pub fn log_info(lua: &Lua, msg: String) -> LuaResult<()> {
+pub fn log_info(lua: &Lua, msg: String) {
     if let Some(ref lib) = *LIBRARY.read().unwrap() {
-        let f: Symbol<fn(lua: &Lua, msg: String) -> LuaResult<()>> = unsafe {
-            lib.get(b"log_info")
-                .map_err(|err| mlua::Error::ExternalError(Arc::new(err)))?
-        };
-        f(lua, msg)
-    } else {
-        Ok(())
+        match unsafe { lib.get::<Symbol<fn(lua: &Lua, msg: String)>>(b"log_info") } {
+            Ok(f) => f(lua, msg),
+            Err(err) => {
+                log::error!("Failed to get `log_info` method: {}", err);
+                return;
+            }
+        }
     }
 }
 
-pub fn log_debug(lua: &Lua, msg: String) -> LuaResult<()> {
+pub fn log_debug(lua: &Lua, msg: String) {
     if let Some(ref lib) = *LIBRARY.read().unwrap() {
-        let f: Symbol<fn(lua: &Lua, msg: String) -> LuaResult<()>> = unsafe {
-            lib.get(b"log_debug")
-                .map_err(|err| mlua::Error::ExternalError(Arc::new(err)))?
-        };
-        f(lua, msg)
-    } else {
-        Ok(())
+        match unsafe { lib.get::<Symbol<fn(lua: &Lua, msg: String)>>(b"log_debug") } {
+            Ok(f) => f(lua, msg),
+            Err(err) => {
+                log::error!("Failed to get `log_debug` method: {}", err);
+                return;
+            }
+        }
     }
 }


### PR DESCRIPTION
We had issues with a crash from an error returned by the `dcs_grpc.dll` in the past, see https://github.com/DCS-gRPC/rust-server/issues/19. We fixed that by directly logging the offending error instead of returning it to Lua, see https://github.com/DCS-gRPC/rust-server/commit/bd54607d0d69b93ceed1815ff105058ea06cadb1.

I've investigated this again. I tried to reproduce this issue outside of DCS (basically with a `lua.exe` and a minimal Lua module written in Rust using `mlua`), but was unsuccessful - I couldn't reproduce it outside of DCS. As I don't have any idea left of how to fix/narrow down this issue, I give up and and would suggest to avoid returning errors from Rust to Lua entirely. This is also what this PR changes. It ensures that all calls to `grpc.*` methods never error. If they encounter an error internally, the error is logged right away and not returned to Lua first.

Drawback: The errors will not land in the `Logs/dcs.log` file and instead only in `Logs/gRPC.log`

Potentially fixes the crash reported by the Enigma server admins (see https://discord.com/channels/696721363276267590/962651858760003594/977730972206366781).
Fixes #138