### PR TITLE
Make Hit/Kill event weaponName field optional

### DIFF
--- a/protos/dcs/mission/v0/mission.proto
+++ b/protos/dcs/mission/v0/mission.proto
@@ -103,7 +103,7 @@ message StreamEventsResponse {
     // The object that has been hit.
     dcs.common.v0.Target target = 3;
     // The weapon the target got hit by.
-    string weapon_name = 4;
+    optional string weapon_name = 4;
   }
 
   // Occurs when an aircraft takes off from an airbase, farp, or ship.
@@ -312,7 +312,7 @@ message StreamEventsResponse {
     dcs.common.v0.Target target = 3;
     // The name of the weapon that killed the target (exists instead of weapon
     // for weapons that trigger the shooting start and end events).
-    string weapon_name = 4;
+    optional string weapon_name = 4;
   }
 
   // A score change (doesn't contain any useful information)


### PR DESCRIPTION
Not all hit and kill events include a `weaponName` depending on what
happened (For example one aircraft hitting another without the use of
an intermediate weapon). This was causing many deserialization errors in
the production logs of servers. Therefore we will make this field
optional.

I think that longterm we can come up with a better solution by removing
the `weaponName` field entirely and only ever populating the `Weapon`
field instead in lua. However this is a short-term fix for the next
release.

Before
```
2022-05-25 08:56:51.722 ERROR   dcs_grpc: failed to deserialize event: deserialize error: missing field `weaponName`
```

After
```
2022-05-27 02:21:51.926 DEBUG   dcs_grpc: Received event: StreamEventsResponse {
    time: 4685.634,
    event: Some(
        Hit(
            HitEvent {
                initiator: Some(
                    Initiator {
                        initiator: Some(
                            Unit(
                                Unit {
                                    id: 331,
                                    name: "Pilot #052",
                                    callsign: "Uzi41",
                                    coalition: Blue,
                                    r#type: "A-10A",
                                    position: Some(
                                        Position {
                                            lat: 42.09250255326369,
                                            lon: 42.043146782078,
                                            alt: 331.12921142578125,
                                        },
                                    ),
                                    player_name: Some(
                                        "CatJones",
                                    ),
                                    group_name: "Kobuleti A-10A Uzi 4",
                                    number_in_group: 1,
                                    speed: 165.22216239514955,
                                    heading: 133.69975484989288,
                                    category: Airplane,
                                },
                            ),
                        ),
                    },
                ),
                weapon: None,
                target: Some(
                    Target {
                        target: Some(
                            Unit(
                                Unit {
                                    id: 7196,
                                    name: "RUSSIA gnd 9 unit10",
                                    callsign: "1",
                                    coalition: Red,
                                    r#type: "BTR-80",
                                    position: Some(
                                        Position {
                                            lat: 42.08276129507955,
                                            lon: 42.05499193881823,
                                            alt: 35.46840286254883,
                                        },
                                    ),
                                    player_name: None,
                                    group_name: "RUSSIA gnd 9",
                                    number_in_group: 7,
                                    speed: 0.0,
                                    heading: 180.0,
                                    category: Ground,
                                },
                            ),
                        ),
                    },
                ),
                weapon_name: None,
            },
        ),
    ),
}
```