### PR TITLE
Add Mission Management APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MarkupToCoalition` API
 - `GetTheatre` API
 - `GetUnitType` API
+- `ReloadCurrentMission` API
+- `LoadNextMission` API
+- `LoadMission` API
 
 ## [0.5.0] - 2022-04-19
 ### Added

--- a/STATUS.md
+++ b/STATUS.md
@@ -110,8 +110,9 @@ should use their independent logging and tracing functions.
 - [ ] <del>`trace`</del> (client applications should use their own logging)
 
 #### GameGUI API
-- [ ] `load_mission`
-- [ ] `load_next_mission`
+- [x] `reload_current_mission` Custom API
+- [x] `load_mission`
+- [x] `load_next_mission`
 
 ### Timer Service
 - [x] `getTime`

--- a/lua/DCS-gRPC/methods/hook.lua
+++ b/lua/DCS-gRPC/methods/hook.lua
@@ -3,7 +3,9 @@
 -- Docs: /DCS World/API/DCS_ControlAPI.html
 --
 
+local DCS = DCS
 local GRPC = GRPC
+local net = net
 
 GRPC.methods.getMissionName = function()
   return GRPC.success({name = DCS.getMissionName()})
@@ -15,6 +17,19 @@ end
 
 GRPC.methods.getMissionDescription = function()
   return GRPC.success({description = DCS.getMissionDescription()})
+end
+
+GRPC.methods.reloadCurrentMission = function()
+  net.load_mission(DCS.getMissionFilename())
+  return GRPC.success({})
+end
+
+GRPC.methods.loadNextMission = function()
+  return GRPC.success({loaded = net.load_next_mission()})
+end
+
+GRPC.methods.loadMission = function(params)
+  return GRPC.success({loaded = net.load_mission(params.fileName)})
 end
 
 GRPC.methods.getPaused = function()

--- a/protos/dcs/hook/v0/hook.proto
+++ b/protos/dcs/hook/v0/hook.proto
@@ -25,6 +25,21 @@ service HookService {
   // https://wiki.hoggitworld.com/view/DCS_func_stopMission
   rpc StopMission(StopMissionRequest) returns (StopMissionResponse) {}
 
+  // Reload the currently running mission
+  rpc ReloadCurrentMission(ReloadCurrentMissionRequest)
+    returns (ReloadCurrentMissionResponse) {}
+
+  // Load the next mission in the server mission list. Note that it does
+  // not loop back to the first mission once the end of the mission list
+  // has been reached
+  rpc LoadNextMission(LoadNextMissionRequest)
+    returns (LoadNextMissionResponse) {}
+
+  // Load a specific mission file. This does not need to be in the mission
+  // list.
+  rpc LoadMission(LoadMissionRequest)
+    returns (LoadMissionResponse) {}
+
   // Evaluate some Lua inside of the hook environment and return the result as a
   // JSON string. Disabled by default.
   rpc Eval(EvalRequest) returns (EvalResponse) {}
@@ -85,6 +100,30 @@ message SetPausedRequest {
 }
 
 message SetPausedResponse {
+}
+
+message ReloadCurrentMissionRequest {
+}
+
+message ReloadCurrentMissionResponse {
+}
+
+message LoadNextMissionRequest {
+}
+
+message LoadNextMissionResponse {
+  // Was the next mission successfully loaded. SHOULD return false when the
+  // end of the mission list has been reached but DCS appears to always
+  // return true
+  bool loaded = 1;
+}
+
+message LoadMissionRequest {
+  // The full path to the .miz file to be loaded
+  string file_name = 1;
+}
+
+message LoadMissionResponse {
 }
 
 message StopMissionRequest {

--- a/src/rpc/hook.rs
+++ b/src/rpc/hook.rs
@@ -45,6 +45,30 @@ impl HookService for HookRpc {
         Ok(Response::new(res))
     }
 
+    async fn reload_current_mission(
+        &self,
+        request: Request<hook::v0::ReloadCurrentMissionRequest>,
+    ) -> Result<Response<hook::v0::ReloadCurrentMissionResponse>, Status> {
+        let res = self.request("reloadCurrentMission", request).await?;
+        Ok(Response::new(res))
+    }
+
+    async fn load_next_mission(
+        &self,
+        request: Request<hook::v0::LoadNextMissionRequest>,
+    ) -> Result<Response<hook::v0::LoadNextMissionResponse>, Status> {
+        let res = self.request("loadNextMission", request).await?;
+        Ok(Response::new(res))
+    }
+
+    async fn load_mission(
+        &self,
+        request: Request<hook::v0::LoadMissionRequest>,
+    ) -> Result<Response<hook::v0::LoadMissionResponse>, Status> {
+        let res = self.request("loadMission", request).await?;
+        Ok(Response::new(res))
+    }
+
     async fn stop_mission(
         &self,
         request: Request<hook::v0::StopMissionRequest>,


### PR DESCRIPTION
Add mission management APIs that allow clients to load and restart
missions. The `LoadNextMission` API is apparently supposed to return
false when the last mission in the mission list has been reached but DCS
is returning true all the time.

The API to reload the current mission is not natively provided
by DCS but is simple to implement and will be useful for admins I think.