### PR TITLE
Include transform in each unit export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `SimulationFps` event that is fired every second and contains simulation fps information since the last event (i.e. for the past ~1sec).
 - Added `GetSessionId` API
 - Added `GetDetectedTargets` API. Method follows the DCS implementation of controller's getDetectedTargets. Can optionally also return the unit or weapon objects tracked by the radar.
+- Added `orientation` and `velocity` to `Unit` object
+- Added `u`/`v` coordinates (offset from DCS map origin in meters) to `Position`s
 
 ### Changed
 - Unit objects now return the full group object in the `group` field to make event processing easier. This replaces the `group_name` and `group_category` fields and is a backwards incompatible change.
+- Updated all vectors to be in DCS' coordinate system (+x north, -x south, +z is east, -z west, +y up and -y down)
 
 ## [0.6.0] - 2022-05-30
 

--- a/lua/DCS-gRPC/methods/atmosphere.lua
+++ b/lua/DCS-gRPC/methods/atmosphere.lua
@@ -6,13 +6,13 @@
 GRPC.methods.getWind = function(params)
   local point = coord.LLtoLO(params.position.lat, params.position.lon, params.position.alt)
 
-  return GRPC.success(GRPC.exporters.vector(atmosphere.getWind(point)))
+  return GRPC.success(atmosphere.getWind(point))
 end
 
 GRPC.methods.getWindWithTurbulence = function(params)
   local point = coord.LLtoLO(params.position.lat, params.position.lon, params.position.alt)
 
-  return GRPC.success(GRPC.exporters.vector(atmosphere.getWindWithTurbulence(point)))
+  return GRPC.success(atmosphere.getWindWithTurbulence(point))
 end
 
 GRPC.methods.getTemperatureAndPressure = function(params)

--- a/lua/DCS-gRPC/methods/unit.lua
+++ b/lua/DCS-gRPC/methods/unit.lua
@@ -66,25 +66,9 @@ GRPC.methods.getUnitTransform = function(params)
     return GRPC.errorNotFound("unit does not exist")
   end
 
-    -- https://wiki.hoggitworld.com/view/DCS_func_getPosition
-  local position = unit:getPosition()
-  local coords = GRPC.exporters.position(position.p)
-  local coordsNorth = coord.LLtoLO(coords.lat + 1, coords.lon)
-
-  -- Response does not exactly match what the gRPC server will return since the gRPC response
-  -- will be calculated based on the information returned here.
   return GRPC.success({
-    position = coords,
-    u = position.p.z,
-    v = position.p.x,
-    positionNorth = GRPC.exporters.vector(coordsNorth),
-    orientation = {
-      forward = GRPC.exporters.vector(position.x),
-      right = GRPC.exporters.vector(position.z),
-      up = GRPC.exporters.vector(position.y),
-    },
-    velocity = GRPC.exporters.vector(unit:getVelocity()),
     time = timer.getTime(),
+    rawTransform = GRPC.exporters.rawTransform(unit),
   })
 end
 
@@ -133,18 +117,4 @@ GRPC.methods.getUnit = function(params)
   end
 
   return GRPC.success({unit = GRPC.exporters.unit(unit)})
-end
-
--- This method is only used by the unit stream. It returns the subset of `getUnit` that can
--- change (like position, velocity, ...). It is not exposed to the gRPC service for now.
-GRPC.methods.getUnitUpdate = function(params)
-  local unit = Unit.getByName(params.name)
-  if unit == nil then
-    return GRPC.errorNotFound("unit `" .. tostring(params.name) .. "` does not exist")
-  end
-
-  return GRPC.success({
-    position = GRPC.exporters.position(unit:getPoint()),
-    velocity = GRPC.exporters.vector(unit:getVelocity()),
-  })
 end

--- a/protos/dcs/common/v0/common.proto
+++ b/protos/dcs/common/v0/common.proto
@@ -171,6 +171,10 @@ message Position {
   double lon = 2;
   // Altitude in Meters above Mean Sea Level (MSL)
   double alt = 3;
+  // Distance between DCS' map origin to object in meters on west-east axis.
+  double u = 4;
+  // Distance between DCS' map origin to object in meters on north-south axis.
+  double v = 5;
 }
 
 /**
@@ -203,18 +207,17 @@ message Unit {
   string type = 5;
   // The position of the unit
   Position position = 6;
+  // The orientation of the unit in both 2D and 3D space
+  Orientation orientation = 7;
+  // The velocity of the unit in both 2D and 3D space
+  Velocity velocity = 8;
   // The name of the player if one is in control of the unit
-  optional string player_name = 7;
+  optional string player_name = 9;
   // The group that the unit belongs to
-  Group group = 8;
+  Group group = 10;
   // The number of this unit in the group. Does not change as units are
   // destroyed
-  uint32 number_in_group = 9;
-  // The horizontal speed of the unit. If it is doing mach one straight up then
-  // the speed will be 0
-  double speed = 10;
-  // The heading of the unit
-  double heading = 11;
+  uint32 number_in_group = 11;
 }
 
 /**
@@ -291,9 +294,9 @@ message Scenery {
  *
  */
 message Airbase {
-  // The DCS generated ID. Only used when the airfield is also a unit
-  // (e.g. an Aicraft Carrier)
-  optional uint32 id = 1;
+  // Information about the unit, if the airbase is one (e.g. in case of a
+  // carrier).
+  optional Unit unit = 1;
   // TODO: Fill this in
   string name = 2;
   // TODO: Fill this in
@@ -378,15 +381,50 @@ message MarkPanel {
 }
 
 /**
- * A vector in a left-handed coordinate system with +z being north, -z south, +x
- * east, -x west, +y up and -y down (as opposed to DCS' unusual right-handed
- * coordinate system where x is north/ south and z is west/east; the underlying
- * conversion is basically swapping `x` and `z` as in `x=z` and `z=x`).
+ * A vector in a right-handed coordinate system where +x is north, -x south, +z
+ * is east, -z west, +y up and -y down.
  */
 message Vector {
   double x = 1;
   double y = 2;
   double z = 3;
+}
+
+/**
+ * The orientation of an object in 3D space.
+ */
+message Orientation {
+  // The heading the nose of the object points to on a flat world.
+  double heading = 1;
+  // Yaw in degrees - clockwise relative to the true north (this is similar to
+  // the heading, just corrected by the projection error when going from a flat
+  // to a spherical world).
+  double yaw = 2;
+  // Pitch in degrees - positive when taking-off.
+  double pitch = 3;
+  // Roll in degrees - positive when rolling the aircraft to the right.
+  double roll = 4;
+  // The normalized direction the object is pointing to.
+  Vector forward = 5;
+  // The normalized direction the three line (right wing) is pointing to.
+  Vector right = 6;
+  // The normalized up vector (orthogonal to forward and right).
+  Vector up = 7;
+}
+
+/**
+ * The orientation of an object in 3D space.
+ */
+message Velocity {
+  // The heading the object is moving to (use `orientation.heading` to get the
+  // heading the nose is pointing to).
+  double heading = 1;
+  // The horizontal speed of the unit. If it is doing mach one straight up then
+  // the speed will be 0
+  double speed = 2;
+  // The direction the object is traveling to, and speed (magnitude of the
+  // vector) the object is traveling with.
+  Vector velocity = 3;
 }
 
 /**

--- a/protos/dcs/mission/v0/mission.proto
+++ b/protos/dcs/mission/v0/mission.proto
@@ -538,7 +538,7 @@ message StreamUnitsResponse {
   }
 
   oneof update {
-    // The unit is either new or its position changed.
+    // The unit is either new or its position or attitude changed.
     dcs.common.v0.Unit unit = 1;
 
     // The unit does not exist anymore.

--- a/protos/dcs/unit/v0/unit.proto
+++ b/protos/dcs/unit/v0/unit.proto
@@ -51,39 +51,15 @@ message GetTransformRequest {
   string name = 1;
 }
 
-/**
- * The orientation of an object in 3D space.
- */
-message Orientation {
-  // The normalized direction the object is pointing to.
-  dcs.common.v0.Vector forward = 1;
-  // The normalized direction the three line (right wing) is pointing to.
-  dcs.common.v0.Vector right = 2;
-  // The normalized up vector (orthogonal to forward and right).
-  dcs.common.v0.Vector up = 3;
-  // Yaw in degrees - clockwise relative to the true north.
-  double yaw = 4;
-  // Pitch in degrees - positive when taking-off.
-  double pitch = 5;
-  // Roll in degrees - positive when rolling the aircraft to the right.
-  double roll = 6;
-}
-
 message GetTransformResponse {
-  dcs.common.v0.Position position = 1;
-  // Distance between DCS' map origin to object in meters on west-east axis.
-  double u = 2;
-  // Distance between DCS' map origin to object in meters on north-south axis.
-  double v = 3;
-  // The heading of the object on a flat world. To get the heading corrected by
-  // the projection error when going from a flat to a spherical world, use
-  // `orientation.yaw` instead.
-  double heading = 4;
-  Orientation orientation = 5;
-  // The direction the object is traveling to, and speed (magnitude of the
-  // vector) the object is traveling with.
-  dcs.common.v0.Vector velocity = 6;
-  double time = 7;  // Time in seconds since the scenario started.
+  // Time in seconds since the scenario started.
+  double time = 1;
+  // The position of the unit
+  dcs.common.v0.Position position = 2;
+  // The orientation of the unit in both 2D and 3D space
+  dcs.common.v0.Orientation orientation = 3;
+  // The velocity of the unit in both 2D and 3D space
+  dcs.common.v0.Velocity velocity = 4;
 }
 
 message GetPlayerNameRequest {

--- a/src/rpc/unit.rs
+++ b/src/rpc/unit.rs
@@ -1,9 +1,6 @@
-use std::ops::Neg;
-
 use super::MissionRpc;
-use serde::Deserialize;
+use stubs::unit;
 use stubs::unit::v0::unit_service_server::UnitService;
-use stubs::{common, unit};
 use tonic::{Request, Response, Status};
 
 #[tonic::async_trait]
@@ -60,51 +57,7 @@ impl UnitService for MissionRpc {
         &self,
         request: Request<unit::v0::GetTransformRequest>,
     ) -> Result<Response<unit::v0::GetTransformResponse>, Status> {
-        #[derive(Debug, Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        struct Orientation {
-            forward: common::v0::Vector,
-            right: common::v0::Vector,
-            up: common::v0::Vector,
-        }
-
-        #[derive(Debug, Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        struct Payload {
-            position: common::v0::Position,
-            u: f64,
-            v: f64,
-            position_north: common::v0::Vector,
-            orientation: Orientation,
-            velocity: common::v0::Vector,
-            time: f64,
-        }
-
-        let res: Payload = self.request("getUnitTransform", request).await?;
-
-        let projection_error = (res.position_north.x - res.u).atan2(res.position_north.z - res.v);
-
-        let forward = &res.orientation.forward;
-        let heading = forward.x.atan2(forward.z);
-
-        Ok(Response::new(unit::v0::GetTransformResponse {
-            position: Some(res.position),
-            u: res.u,
-            v: res.v,
-            heading: heading.to_degrees(),
-            orientation: Some({
-                let right = &res.orientation.right;
-                unit::v0::Orientation {
-                    up: Some(res.orientation.up),
-                    pitch: forward.y.asin().to_degrees(),
-                    yaw: (heading - projection_error).to_degrees(),
-                    roll: right.y.asin().neg().to_degrees(),
-                    forward: Some(res.orientation.forward),
-                    right: Some(res.orientation.right),
-                }
-            }),
-            velocity: Some(res.velocity),
-            time: res.time,
-        }))
+        let res = self.request("getUnitTransform", request).await?;
+        Ok(Response::new(res))
     }
 }

--- a/stubs/build.rs
+++ b/stubs/build.rs
@@ -11,6 +11,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "dcs.mission.v0.StreamEventsResponse.event",
             "#[serde(tag = \"type\")]",
         )
+        .type_attribute(
+            "dcs.common.v0.Unit",
+            "#[serde(from = \"UnitIntermediate\")]",
+        )
+        .type_attribute(
+            "dcs.unit.v0.GetTransformResponse",
+            "#[serde(from = \"GetTransformResponseIntermediate\")]",
+        )
+        .type_attribute(
+            "dcs.mission.v0.StreamUnitsResponse.update",
+            "#[allow(clippy::large_enum_variant)]",
+        )
         .field_attribute(
             "dcs.mission.v0.StreamEventsResponse.MarkAddEvent.visibility",
             "#[serde(flatten)]",

--- a/stubs/src/atmosphere.rs
+++ b/stubs/src/atmosphere.rs
@@ -1,0 +1,3 @@
+pub mod v0 {
+    tonic::include_proto!("dcs.atmosphere.v0");
+}

--- a/stubs/src/coalition.rs
+++ b/stubs/src/coalition.rs
@@ -1,0 +1,3 @@
+pub mod v0 {
+    tonic::include_proto!("dcs.coalition.v0");
+}

--- a/stubs/src/common.rs
+++ b/stubs/src/common.rs
@@ -1,0 +1,125 @@
+pub mod v0 {
+    use std::ops::Neg;
+
+    tonic::include_proto!("dcs.common.v0");
+
+    #[derive(Default, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub(crate) struct RawTransform {
+        pub position: Option<Position>,
+        pub position_north: Option<Vector>,
+        pub forward: Option<Vector>,
+        pub right: Option<Vector>,
+        pub up: Option<Vector>,
+        pub velocity: Option<Vector>,
+    }
+
+    pub(crate) struct Transform {
+        pub position: Position,
+        pub orientation: Orientation,
+        pub velocity: Velocity,
+    }
+
+    impl From<RawTransform> for Transform {
+        fn from(raw: RawTransform) -> Self {
+            let RawTransform {
+                position,
+                position_north,
+                forward,
+                right,
+                up,
+                velocity,
+            } = raw;
+            let position = position.unwrap_or_default();
+            let position_north = position_north.unwrap_or_default();
+            let forward = forward.unwrap_or_default();
+            let right = right.unwrap_or_default();
+            let up = up.unwrap_or_default();
+            let velocity = velocity.unwrap_or_default();
+
+            let projection_error =
+                (position_north.z - position.u).atan2(position_north.x - position.v);
+            let heading = forward.z.atan2(forward.x);
+
+            let orientation = Orientation {
+                heading: {
+                    let heading = heading.to_degrees();
+                    if heading < 0.0 {
+                        heading + 360.0
+                    } else {
+                        heading
+                    }
+                },
+                yaw: (heading - projection_error).to_degrees(),
+                roll: right.y.asin().neg().to_degrees(),
+                pitch: forward.y.asin().to_degrees(),
+                forward: Some(forward),
+                right: Some(right),
+                up: Some(up),
+            };
+
+            let velocity = Velocity {
+                heading: {
+                    let heading = velocity.z.atan2(velocity.x).to_degrees();
+                    if heading < 0.0 {
+                        heading + 360.0
+                    } else {
+                        heading
+                    }
+                },
+                speed: (velocity.x.powi(2) + velocity.z.powi(2)).sqrt(),
+                velocity: Some(velocity),
+            };
+
+            Transform {
+                position,
+                orientation,
+                velocity,
+            }
+        }
+    }
+
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct UnitIntermediate {
+        id: u32,
+        name: String,
+        callsign: String,
+        coalition: i32,
+        r#type: String,
+        player_name: Option<String>,
+        group: Option<Group>,
+        number_in_group: u32,
+        raw_transform: Option<RawTransform>,
+    }
+
+    impl From<UnitIntermediate> for Unit {
+        fn from(i: UnitIntermediate) -> Self {
+            let UnitIntermediate {
+                id,
+                name,
+                callsign,
+                coalition,
+                r#type,
+                player_name,
+                group,
+                number_in_group,
+                raw_transform,
+            } = i;
+            let transform = Transform::from(raw_transform.unwrap_or_default());
+            Unit {
+                id,
+                name,
+                callsign,
+                coalition,
+                r#type,
+                position: Some(transform.position),
+                orientation: Some(transform.orientation),
+                velocity: Some(transform.velocity),
+                player_name,
+                group,
+                number_in_group,
+            }
+        }
+    }
+}

--- a/stubs/src/controller.rs
+++ b/stubs/src/controller.rs
@@ -1,0 +1,3 @@
+pub mod v0 {
+    tonic::include_proto!("dcs.controller.v0");
+}

--- a/stubs/src/custom.rs
+++ b/stubs/src/custom.rs
@@ -1,0 +1,3 @@
+pub mod v0 {
+    tonic::include_proto!("dcs.custom.v0");
+}

--- a/stubs/src/group.rs
+++ b/stubs/src/group.rs
@@ -1,0 +1,3 @@
+pub mod v0 {
+    tonic::include_proto!("dcs.group.v0");
+}

--- a/stubs/src/hook.rs
+++ b/stubs/src/hook.rs
@@ -1,0 +1,3 @@
+pub mod v0 {
+    tonic::include_proto!("dcs.hook.v0");
+}

--- a/stubs/src/lib.rs
+++ b/stubs/src/lib.rs
@@ -2,88 +2,25 @@
 // https://github.com/tokio-rs/prost/issues/661#issuecomment-1156606409
 #![allow(clippy::derive_partial_eq_without_eq)]
 
+pub mod atmosphere;
+pub mod coalition;
+pub mod common;
+pub mod controller;
+pub mod custom;
+pub mod group;
+pub mod hook;
+pub mod mission;
+pub mod net;
+pub mod timer;
+pub mod trigger;
+pub mod unit;
 mod utils;
-
-pub mod atmosphere {
-    pub mod v0 {
-        tonic::include_proto!("dcs.atmosphere.v0");
-    }
-}
-
-pub mod coalition {
-    pub mod v0 {
-        tonic::include_proto!("dcs.coalition.v0");
-    }
-}
-
-pub mod common {
-    pub mod v0 {
-        tonic::include_proto!("dcs.common.v0");
-    }
-}
-
-pub mod controller {
-    pub mod v0 {
-        tonic::include_proto!("dcs.controller.v0");
-    }
-}
-
-pub mod custom {
-    pub mod v0 {
-        tonic::include_proto!("dcs.custom.v0");
-    }
-}
-
-pub mod group {
-    pub mod v0 {
-        tonic::include_proto!("dcs.group.v0");
-    }
-}
-
-pub mod hook {
-    pub mod v0 {
-        tonic::include_proto!("dcs.hook.v0");
-    }
-}
-
-pub mod mission {
-    pub mod v0 {
-        tonic::include_proto!("dcs.mission.v0");
-    }
-}
-
-pub mod net {
-    pub mod v0 {
-        tonic::include_proto!("dcs.net.v0");
-    }
-}
-
-pub mod timer {
-    pub mod v0 {
-        tonic::include_proto!("dcs.timer.v0");
-    }
-}
-
-pub mod trigger {
-    pub mod v0 {
-        tonic::include_proto!("dcs.trigger.v0");
-    }
-}
-
-pub mod unit {
-    pub mod v0 {
-        tonic::include_proto!("dcs.unit.v0");
-    }
-}
-
-pub mod world {
-    pub mod v0 {
-        tonic::include_proto!("dcs.world.v0");
-    }
-}
+pub mod world;
 
 #[cfg(test)]
 mod tests {
+    use crate::common::v0::{Orientation, Velocity};
+
     use super::common::v0::{
         initiator, Airbase, AirbaseCategory, Coalition, Initiator, Position, Unit,
     };
@@ -103,7 +40,7 @@ mod tests {
         );
     }
 
-    // Note that this string sumulates the response from Lua. This is important as it is
+    // Note that this string simulates the response from Lua. This is important as it is
     // _after_ increment changes to enums to cater to gRPC enum indexing where 0 is not allowed
     // for responses.
     #[test]
@@ -122,16 +59,8 @@ mod tests {
                                     "callsign": "Enfield11",
                                     "coalition": 3,
                                     "type": "FA-18C_hornet",
-                                    "position": {
-                                        "lat": 3,
-                                        "lon": 2,
-                                        "alt": 1,
-                                        "time": 0
-                                    },
                                     "playerName": "New callsign",
-                                    "numberInGroup": 1,
-                                    "heading": 0.5,
-                                    "speed": 0.8
+                                    "numberInGroup": 1
                                 }
                             }
 		                },
@@ -141,7 +70,8 @@ mod tests {
 			                "lat": 1,
 			                "lon": 2,
 			                "alt": 3,
-                            "time": 4
+                            "u": 4,
+                            "v": 5
 		                },
 		                "text": "Test"
 	                }
@@ -161,16 +91,24 @@ mod tests {
                             callsign: "Enfield11".to_string(),
                             r#type: "FA-18C_hornet".to_string(),
                             coalition: Coalition::Blue.into(),
-                            position: Some(Position {
-                                lat: 3.0,
-                                lon: 2.0,
-                                alt: 1.0,
-                            }),
                             player_name: Some("New callsign".to_string()),
                             group: None,
                             number_in_group: 1,
-                            heading: 0.5,
-                            speed: 0.8,
+                            position: Some(Default::default()),
+                            orientation: Some(Orientation {
+                                heading: Default::default(),
+                                yaw: Default::default(),
+                                pitch: Default::default(),
+                                roll: Default::default(),
+                                forward: Some(Default::default()),
+                                right: Some(Default::default()),
+                                up: Some(Default::default()),
+                            }),
+                            velocity: Some(Velocity {
+                                heading: Default::default(),
+                                speed: Default::default(),
+                                velocity: Some(Default::default())
+                            }),
                         }))
                     }),
                     visibility: Some(event::mark_add_event::Visibility::Coalition(
@@ -181,6 +119,8 @@ mod tests {
                         lat: 1.0,
                         lon: 2.0,
                         alt: 3.0,
+                        u: 4.0,
+                        v: 5.0,
                     }),
                     text: "Test".to_string(),
                 })),
@@ -206,7 +146,8 @@ mod tests {
                                 "lon": 37.35978347755592,
                                 "lat": 45.01317473377168,
                                 "alt": 43.00004196166992,
-                                "time": 0.0
+                                "u": 0,
+                                "v": 0
                             },
                             "category": 1,
                             "displayName": "Anapa-Vityazevo"
@@ -220,7 +161,7 @@ mod tests {
             resp,
             GetAirbasesResponse {
                 airbases: vec![Airbase {
-                    id: None,
+                    unit: None,
                     name: "Anapa-Vityazevo".to_string(),
                     callsign: "Anapa-Vityazevo".to_string(),
                     coalition: Coalition::Neutral.into(),
@@ -228,6 +169,8 @@ mod tests {
                         lon: 37.35978347755592,
                         lat: 45.01317473377168,
                         alt: 43.00004196166992,
+                        u: 0.0,
+                        v: 0.0,
                     }),
                     category: AirbaseCategory::Airdrome.into(),
                     display_name: "Anapa-Vityazevo".to_string(),

--- a/stubs/src/lib.rs
+++ b/stubs/src/lib.rs
@@ -1,6 +1,7 @@
 // Current recommendation as of
 // https://github.com/tokio-rs/prost/issues/661#issuecomment-1156606409
 #![allow(clippy::derive_partial_eq_without_eq)]
+#![allow(clippy::large_enum_variant)]
 
 pub mod atmosphere;
 pub mod coalition;

--- a/stubs/src/mission.rs
+++ b/stubs/src/mission.rs
@@ -1,0 +1,3 @@
+pub mod v0 {
+    tonic::include_proto!("dcs.mission.v0");
+}

--- a/stubs/src/net.rs
+++ b/stubs/src/net.rs
@@ -1,0 +1,3 @@
+pub mod v0 {
+    tonic::include_proto!("dcs.net.v0");
+}

--- a/stubs/src/timer.rs
+++ b/stubs/src/timer.rs
@@ -1,0 +1,3 @@
+pub mod v0 {
+    tonic::include_proto!("dcs.timer.v0");
+}

--- a/stubs/src/trigger.rs
+++ b/stubs/src/trigger.rs
@@ -1,0 +1,3 @@
+pub mod v0 {
+    tonic::include_proto!("dcs.trigger.v0");
+}

--- a/stubs/src/unit.rs
+++ b/stubs/src/unit.rs
@@ -1,0 +1,28 @@
+pub mod v0 {
+    use crate::common::v0::{RawTransform, Transform};
+
+    tonic::include_proto!("dcs.unit.v0");
+
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct GetTransformResponseIntermediate {
+        time: f64,
+        raw_transform: Option<RawTransform>,
+    }
+
+    impl From<GetTransformResponseIntermediate> for GetTransformResponse {
+        fn from(i: GetTransformResponseIntermediate) -> Self {
+            let GetTransformResponseIntermediate {
+                time,
+                raw_transform,
+            } = i;
+            let transform = Transform::from(raw_transform.unwrap_or_default());
+            GetTransformResponse {
+                time,
+                position: Some(transform.position),
+                orientation: Some(transform.orientation),
+                velocity: Some(transform.velocity),
+            }
+        }
+    }
+}

--- a/stubs/src/world.rs
+++ b/stubs/src/world.rs
@@ -1,0 +1,3 @@
+pub mod v0 {
+    tonic::include_proto!("dcs.world.v0");
+}


### PR DESCRIPTION
Opening as draft to see if this is something we want to do. If so, I'll finish it up (fixing tests, adding missing changelog entry, etc).

This PR includes the information currently only retrieved via `GetTransform` in the `Unit` message. This makes this data available everywhere we have units (unit stream, events, ...).

## Motivation

I am still working on an LSO, which was also the reason I've added `GetTransform` in the first place. I've now faced the challenge that I needed the information of `GetTransform` at the exact time of a land event. Sending a `GetTransform` after receiving the event yields data that is already newer than the event (units already moved since), which is why I need the information included in the event itself.

With this change, the information also ends up in the units stream, which would solve parts of #159.

## Drawback

More calculations and Lua calls done per unit export. Might effect the performance - though I am not sure if it is even a realistic effect to worry about?
