### PR TITLE
Add FPS event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 - Fixed error when retrieving mark panels (`WorldService.GetMarkPanels`) when the mark panel was created by a game master / JTAC, or when the player who created the mark panel left. `MarkPanel.initiator` is now optional. ([#156](https://github.com/DCS-gRPC/rust-server/issues/156))
 
+### Added
+- Added `SimulationFps` event that is fired every second and contains simulation fps information since the last event (i.e. for the past ~1sec).
+
 ## [0.6.0] - 2022-05-30
 
 ### Added

--- a/lua/DCS-gRPC/grpc.lua
+++ b/lua/DCS-gRPC/grpc.lua
@@ -253,6 +253,8 @@ else -- hook env
   local skipFrames = math.ceil(interval / 0.016) -- 0.016 = 16ms = 1 frame at 60fps
   local frame = 0
   function GRPC.onSimulationFrame()
+    grpc.simulationFrame(DCS.getModelTime())
+
     frame = frame + 1
     if frame >= skipFrames then
       frame = 0

--- a/protos/dcs/mission/v0/mission.proto
+++ b/protos/dcs/mission/v0/mission.proto
@@ -377,7 +377,7 @@ message StreamEventsResponse {
     // The slot's identifier
     string slot_id = 3;
   }
-  
+
   /**
    * Fired when a player connected to the server.
    */
@@ -443,6 +443,15 @@ message StreamEventsResponse {
     google.protobuf.Struct details = 2;
   }
 
+  /**
+   * Fired every second containing simulation FPS information since the previous
+   * event.
+   */
+  message SimulationFpsEvent {
+    // The average FPS since the last event.
+    double average = 1;
+  }
+
   // The event's mission time.
   double time = 1;
   oneof event {
@@ -494,6 +503,7 @@ message StreamEventsResponse {
     MissionCommandEvent mission_command = 8196;
     CoalitionCommandEvent coalition_command = 8197;
     GroupCommandEvent group_command = 8198;
+    SimulationFpsEvent simulation_fps = 8199;
   }
 }
 
@@ -604,7 +614,7 @@ message RemoveMissionCommandItemResponse {
 // The emitted event will include the coalition.
 message AddCoalitionCommandRequest {
   // The coalition whose players will be able to see and run the command
-  dcs.common.v0.Coalition coalition = 1; 
+  dcs.common.v0.Coalition coalition = 1;
   // The name of the command that is displayed to the player.
   // It will form the last entry in the returned path.
   string name = 2;
@@ -644,7 +654,7 @@ message AddCoalitionCommandSubMenuResponse {
 
 message RemoveCoalitionCommandItemRequest {
   // The coalition whose players will have the menu item removed
-  dcs.common.v0.Coalition coalition = 1; 
+  dcs.common.v0.Coalition coalition = 1;
   // The full path to the menu item, which can be a submenu or a command, to be
   // removed. Deleting a menu item will delete all children it may have.
   repeated string path = 2;

--- a/src/fps.rs
+++ b/src/fps.rs
@@ -1,0 +1,57 @@
+use std::future::Future;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
+
+use dcs_module_ipc::IPC;
+use stubs::mission::v0::stream_events_response::{Event, SimulationFpsEvent};
+use stubs::mission::v0::StreamEventsResponse;
+use tokio::time::{interval, MissedTickBehavior};
+
+static FPS: AtomicU32 = AtomicU32::new(0);
+static TIME: AtomicU32 = AtomicU32::new(0);
+
+pub fn frame(time: f64) {
+    // Increase the frame count by one
+    FPS.fetch_add(1, Ordering::Relaxed);
+
+    // Update the DCS simulation time (convert it to an int as there are no atomic floats)
+    TIME.store((time * 1000.0) as u32, Ordering::Relaxed);
+}
+
+pub async fn run_in_background(
+    ipc: IPC<StreamEventsResponse>,
+    mut shutdown_signal: impl Future<Output = ()> + Unpin,
+) {
+    let mut interval = interval(Duration::from_secs(1));
+    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+    // clear FPS counter when first being started
+    let mut previous = interval.tick().await;
+    FPS.store(0, Ordering::Relaxed);
+
+    loop {
+        // wait for either the shutdown signal or the next interval tick, whatever happens first
+        let instant = tokio::select! {
+            _ = &mut shutdown_signal => {
+                break
+            }
+            instant = interval.tick() => instant
+        };
+
+        // Technically, there could be a simulation frame between the read of `frame_count` and
+        // `time` so that `time` already receives a newer value. However, this should be rare and
+        // shouldn't really matter for the resolution measured here.
+        let frame_count = FPS.swap(0, Ordering::Relaxed);
+        let time = TIME.load(Ordering::Relaxed);
+
+        let elapsed = instant - previous;
+        previous = instant;
+        let average = (frame_count as f64) / elapsed.as_secs_f64();
+
+        ipc.event(StreamEventsResponse {
+            time: f64::from(time) / 1000.0,
+            event: Some(Event::SimulationFps(SimulationFpsEvent { average })),
+        })
+        .await;
+    }
+}

--- a/src/hot_reload.rs
+++ b/src/hot_reload.rs
@@ -71,6 +71,18 @@ pub fn event(lua: &Lua, event: Value) -> LuaResult<()> {
     }
 }
 
+pub fn simulation_frame(lua: &Lua, time: f64) -> LuaResult<()> {
+    if let Some(ref lib) = *LIBRARY.read().unwrap() {
+        let f: Symbol<fn(lua: &Lua, time: f64) -> LuaResult<()>> = unsafe {
+            lib.get(b"simulation_frame")
+                .map_err(|err| mlua::Error::ExternalError(Arc::new(err)))?
+        };
+        f(lua, time)
+    } else {
+        Ok(())
+    }
+}
+
 pub fn log_error(lua: &Lua, err: String) -> LuaResult<()> {
     if let Some(ref lib) = *LIBRARY.read().unwrap() {
         let f: Symbol<fn(lua: &Lua, err: String) -> LuaResult<()>> = unsafe {

--- a/src/server.rs
+++ b/src/server.rs
@@ -94,6 +94,11 @@ impl Server {
 
         self.runtime
             .spawn(self.state.stats.clone().run_in_background());
+
+        self.runtime.spawn(crate::fps::run_in_background(
+            self.state.ipc_mission.clone(),
+            self.shutdown.handle().signal(),
+        ));
     }
 
     pub fn stop_blocking(mut self) {


### PR DESCRIPTION
Calculate FPS by hooking into `onSimulationFrame` and fire an event
every second containing the FPS since the last event (~1s).

Resolves #164

![image](https://user-images.githubusercontent.com/409021/176259757-856d3349-67c2-4ca4-b050-59a2bb6bf206.png)
