### PR TITLE
Add individual frame times to SimulationFps event

### DIFF
--- a/lua/DCS-gRPC/grpc.lua
+++ b/lua/DCS-gRPC/grpc.lua
@@ -253,7 +253,7 @@ else -- hook env
   local skipFrames = math.ceil(interval / 0.016) -- 0.016 = 16ms = 1 frame at 60fps
   local frame = 0
   function GRPC.onSimulationFrame()
-    grpc.simulationFrame(DCS.getModelTime())
+    grpc.simulationFrame(DCS.getModelTime(), DCS.getRealTime())
 
     frame = frame + 1
     if frame >= skipFrames then

--- a/protos/dcs/mission/v0/mission.proto
+++ b/protos/dcs/mission/v0/mission.proto
@@ -453,8 +453,16 @@ message StreamEventsResponse {
    * event.
    */
   message SimulationFpsEvent {
-    // The average FPS since the last event.
-    double average = 1;
+    // Time between frames in ms.
+    repeated float frames_in_dcs_time = 1;
+    float average_in_dcs_time = 2;
+    float lowest_in_dcs_time = 3;
+    float highest_in_dcs_time = 4;
+    // Time between frames in ms.
+    repeated float frames_in_rust_time = 5;
+    float average_in_rust_time = 6;
+    float lowest_in_rust_time = 7;
+    float highest_in_rust_time = 8;
   }
 
   // The event's mission time.

--- a/src/fps.rs
+++ b/src/fps.rs
@@ -1,21 +1,52 @@
 use std::future::Future;
-use std::sync::atomic::{AtomicU32, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use dcs_module_ipc::IPC;
+use once_cell::sync::Lazy;
 use stubs::mission::v0::stream_events_response::{Event, SimulationFpsEvent};
 use stubs::mission::v0::StreamEventsResponse;
+use tokio::sync::Mutex;
 use tokio::time::{interval, MissedTickBehavior};
 
-static FPS: AtomicU32 = AtomicU32::new(0);
-static TIME: AtomicU32 = AtomicU32::new(0);
+static FPS: Lazy<Mutex<Option<Fps>>> = Lazy::new(Default::default);
 
-pub fn frame(time: f64) {
-    // Increase the frame count by one
-    FPS.fetch_add(1, Ordering::Relaxed);
+struct Fps {
+    /// The DCS simulation time of the last update.
+    simulation_time: f64,
+    /// The DCS real time of the last update.
+    real_time: f64,
+    /// The instant the previous frame got measured.
+    previous: Instant,
+    /// Collection of frame times in milliseconds.
+    frames_in_dcs_time: Vec<f32>,
+    /// Collection of frame times in milliseconds.
+    frames_in_rust_time: Vec<f32>,
+}
 
-    // Update the DCS simulation time (convert it to an int as there are no atomic floats)
-    TIME.store((time * 1000.0) as u32, Ordering::Relaxed);
+pub fn frame(simulation_time: f64, real_time: f64) {
+    let mut fps = FPS.blocking_lock();
+    let mut fps = match fps.as_mut() {
+        Some(fps) => fps,
+        None => {
+            *fps = Some(Fps {
+                simulation_time,
+                real_time,
+                previous: Instant::now(),
+                frames_in_dcs_time: Vec::with_capacity(300),
+                frames_in_rust_time: Vec::with_capacity(300),
+            });
+            return;
+        }
+    };
+
+    fps.frames_in_dcs_time
+        .push(((real_time - fps.real_time) * 1000.0) as f32);
+    fps.frames_in_rust_time
+        .push(fps.previous.elapsed().as_secs_f32() * 1000.0);
+
+    fps.simulation_time = simulation_time;
+    fps.real_time = real_time;
+    fps.previous = Instant::now();
 }
 
 pub async fn run_in_background(
@@ -25,33 +56,97 @@ pub async fn run_in_background(
     let mut interval = interval(Duration::from_secs(1));
     interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
-    // clear FPS counter when first being started
-    let mut previous = interval.tick().await;
-    FPS.store(0, Ordering::Relaxed);
+    // clear FPS stats when first being started
+    reset().await;
+
+    // keep another instance around to switch instances instead of creating new ones each time the
+    // interval ticks
+    let mut fps = Fps {
+        simulation_time: 0.0,
+        real_time: 0.0,
+        previous: Instant::now(),
+        frames_in_dcs_time: Vec::with_capacity(300),
+        frames_in_rust_time: Vec::with_capacity(300),
+    };
 
     loop {
         // wait for either the shutdown signal or the next interval tick, whatever happens first
-        let instant = tokio::select! {
+        tokio::select! {
             _ = &mut shutdown_signal => {
                 break
             }
-            instant = interval.tick() => instant
+            _ = interval.tick() => {}
         };
 
-        // Technically, there could be a simulation frame between the read of `frame_count` and
-        // `time` so that `time` already receives a newer value. However, this should be rare and
-        // shouldn't really matter for the resolution measured here.
-        let frame_count = FPS.swap(0, Ordering::Relaxed);
-        let time = TIME.load(Ordering::Relaxed);
+        // scope the mutex access to release the lock as soon as possible
+        {
+            let mut current = FPS.lock().await;
+            match current.as_mut() {
+                Some(current) => {
+                    // swap out the current instance to be able to release the lock right away
+                    fps.simulation_time = current.simulation_time;
+                    fps.real_time = current.real_time;
+                    fps.previous = current.previous;
+                    std::mem::swap(current, &mut fps);
+                }
+                None => continue,
+            }
+        }
 
-        let elapsed = instant - previous;
-        previous = instant;
-        let average = (frame_count as f64) / elapsed.as_secs_f64();
+        let dcs_time = fps.frames_in_dcs_time.iter().copied().sum::<f32>();
+        let average_in_dcs_time = fps.frames_in_dcs_time.len() as f32 / (dcs_time / 1000.0);
+        let lowest_in_dcs_time = dcs_time
+            / fps
+                .frames_in_dcs_time
+                .iter()
+                .copied()
+                .fold(f32::NEG_INFINITY, f32::max);
+        let highest_in_dcs_time = dcs_time
+            / fps
+                .frames_in_dcs_time
+                .iter()
+                .copied()
+                .fold(f32::INFINITY, f32::min);
+
+        let rust_time: f32 = fps.frames_in_rust_time.iter().sum::<f32>();
+        let average_in_rust_time = fps.frames_in_rust_time.len() as f32 / (rust_time / 1000.0);
+        let lowest_in_rust_time = rust_time
+            / fps
+                .frames_in_rust_time
+                .iter()
+                .copied()
+                .fold(f32::NEG_INFINITY, f32::max);
+        let highest_in_rust_time = rust_time
+            / fps
+                .frames_in_rust_time
+                .iter()
+                .copied()
+                .fold(f32::INFINITY, f32::min);
 
         ipc.event(StreamEventsResponse {
-            time: f64::from(time) / 1000.0,
-            event: Some(Event::SimulationFps(SimulationFpsEvent { average })),
+            time: fps.simulation_time,
+            event: Some(Event::SimulationFps(SimulationFpsEvent {
+                frames_in_dcs_time: fps.frames_in_dcs_time.clone(),
+                average_in_dcs_time,
+                lowest_in_dcs_time,
+                highest_in_dcs_time,
+                frames_in_rust_time: fps.frames_in_rust_time.clone(),
+                average_in_rust_time,
+                lowest_in_rust_time,
+                highest_in_rust_time,
+            })),
         })
         .await;
+
+        // prepare fps variable to be reused in next iteration
+        fps.frames_in_dcs_time.clear();
+        fps.frames_in_dcs_time.shrink_to(512);
+        fps.frames_in_rust_time.clear();
+        fps.frames_in_rust_time.shrink_to(512);
     }
+}
+
+async fn reset() {
+    let mut fps = FPS.lock().await;
+    *fps = None;
 }

--- a/src/hot_reload.rs
+++ b/src/hot_reload.rs
@@ -71,13 +71,13 @@ pub fn event(lua: &Lua, event: Value) -> LuaResult<()> {
     }
 }
 
-pub fn simulation_frame(lua: &Lua, time: f64) -> LuaResult<()> {
+pub fn simulation_frame(lua: &Lua, arg: (f64, f64)) -> LuaResult<()> {
     if let Some(ref lib) = *LIBRARY.read().unwrap() {
-        let f: Symbol<fn(lua: &Lua, time: f64) -> LuaResult<()>> = unsafe {
+        let f: Symbol<fn(lua: &Lua, arg: (f64, f64)) -> LuaResult<()>> = unsafe {
             lib.get(b"simulation_frame")
                 .map_err(|err| mlua::Error::ExternalError(Arc::new(err)))?
         };
-        f(lua, time)
+        f(lua, arg)
     } else {
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,8 +193,8 @@ pub fn event(lua: &Lua, event: Value) -> LuaResult<()> {
 // This method is called on each simulation frame, so make sure to do as few as possible (avoid
 // even getting a lock on [SERVER]).
 #[no_mangle]
-pub fn simulation_frame(_lua: &Lua, time: f64) -> LuaResult<()> {
-    crate::fps::frame(time);
+pub fn simulation_frame(_lua: &Lua, (simulation_time, real_time): (f64, f64)) -> LuaResult<()> {
+    crate::fps::frame(simulation_time, real_time);
 
     Ok(())
 }


### PR DESCRIPTION
For now, just something for @rurounijones to play with to see if it holds any value when put into a graph.

See inline comments for more details.

<details>
<summary>Example event</summary>

```json
{
  "time": 7.815,
  "simulationFps": {
    "framesInDcsTime": [
      14.5677,
      16.2601,
      14.777,
      16.4022,
      14.7582,
      15.9629,
      15.1631,
      15.8672,
      15.941,
      15.4039,
      15.7125,
      16.0138,
      15.172,
      15.0924,
      15.0716,
      15.1123,
      16.323,
      15.2616,
      16.218,
      16.1462,
      14.3271,
      15.8165,
      14.7448,
      15.6698,
      14.9792,
      16.1596,
      15.0279,
      15.9085,
      14.7911,
      16.3054,
      14.8479,
      14.9969,
      15.7142,
      15.7701,
      15.2827,
      15.0592,
      15.5705,
      15.8951,
      15.4643,
      14.87,
      16.1525,
      15.3772,
      14.9714,
      15.1618,
      15.2051,
      16.3076,
      15.7589,
      15.4135,
      15.9488,
      14.5648,
      15.3497,
      16.411,
      15.735,
      15.0249,
      28.1588,
      3.5851,
      15.1684,
      16.0844,
      15.1631,
      16.4028,
      14.4048,
      15.8459,
      15.9283,
      15.1373,
      15.197
    ],
    "averageInDcsTime": 64.555504,
    "lowestInDcsTime": 35.7574,
    "highestInDcsTime": 280.85284,
    "framesInRustTime": [
      14.5873,
      16.2375,
      14.8058,
      16.370401,
      14.7912,
      15.9337,
      15.1819,
      15.8433,
      15.9695,
      15.3767,
      15.7328005,
      15.9941,
      15.191299,
      15.0724,
      15.0885,
      15.0943,
      16.3428,
      15.2413,
      16.2367,
      16.1296,
      14.3422,
      15.7995,
      14.764299,
      15.659301,
      14.9931,
      16.1367,
      15.042601,
      15.9005,
      14.8068,
      16.2804,
      14.8449,
      15.0187,
      15.6905,
      15.7967005,
      15.256101,
      15.086101,
      15.542,
      15.917,
      15.4472,
      14.892799,
      16.1243,
      15.3974,
      14.9565,
      15.1763,
      15.191099,
      16.321201,
      15.7381,
      15.4376,
      15.9257,
      14.5913,
      15.322101,
      16.434399,
      15.712001,
      15.0402,
      28.1432,
      3.6085,
      15.143,
      16.102,
      15.1489,
      16.399199,
      14.4226,
      15.846901,
      15.929099,
      15.1432,
      15.1896
    ],
    "averageInRustTime": 64.55567,
    "lowestInRustTime": 35.77713,
    "highestInRustTime": 279.03088
  }
}
```

</details>
