### PR TITLE
Return the full parent group with the unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixes
+### Fixed
 - Fixed error when retrieving mark panels (`WorldService.GetMarkPanels`) when the mark panel was created by a game master / JTAC, or when the player who created the mark panel left. `MarkPanel.initiator` is now optional. ([#156](https://github.com/DCS-gRPC/rust-server/issues/156))
 
 ### Added
 - Added `SimulationFps` event that is fired every second and contains simulation fps information since the last event (i.e. for the past ~1sec).
 - Added `GetSessionId` API
+
+### Changed
+- Unit objects now return the full group object in the `group` field to make event processing easier. This replaces the `group_name` and `group_category` fields and is a backwards incompatible change.
 
 ## [0.6.0] - 2022-05-30
 

--- a/lua/DCS-gRPC/exporters/object.lua
+++ b/lua/DCS-gRPC/exporters/object.lua
@@ -42,11 +42,10 @@ GRPC.exporters.unit = function(unit)
     type = unit:getTypeName(),
     position = GRPC.exporters.position(unit:getPoint()),
     playerName = Unit.getPlayerName(unit),
-    groupName = Unit.getGroup(unit):getName(),
+    group = GRPC.exporters.group(Unit.getGroup(unit)),
     numberInGroup = unit:getNumber(),
     heading = heading,
     speed = speed,
-    category = unit:getGroup():getCategory() + 1, -- Increment for non zero-indexed gRPC enum
   }
 end
 

--- a/protos/dcs/common/v0/common.proto
+++ b/protos/dcs/common/v0/common.proto
@@ -205,8 +205,8 @@ message Unit {
   Position position = 6;
   // The name of the player if one is in control of the unit
   optional string player_name = 7;
-  // The name of the group that the unit belongs to
-  string group_name = 8;
+  // The group that the unit belongs to
+  Group group = 8;
   // The number of this unit in the group. Does not change as units are
   // destroyed
   uint32 number_in_group = 9;
@@ -215,8 +215,6 @@ message Unit {
   double speed = 10;
   // The heading of the unit
   double heading = 11;
-  // The group category.
-  GroupCategory category = 12;
 }
 
 /**

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -141,8 +141,11 @@ async fn handle_event(
         }) => {
             // if we are monitoring all the categories, let's watch it.
             // otherwise, we need to be selective on the units we are monitoring
-            let unit_category =
-                GroupCategory::from_i32(unit.category).unwrap_or(GroupCategory::Unspecified);
+            let unit_category = unit
+                .group
+                .as_ref()
+                .and_then(|group| GroupCategory::from_i32(group.category))
+                .unwrap_or(GroupCategory::Unspecified);
             if category == unit_category || category == GroupCategory::Unspecified {
                 state.ctx.tx.send(Ok(Update::Unit(unit.clone()))).await?;
                 state.units.insert(unit.name.clone(), UnitState::new(unit));

--- a/stubs/src/lib.rs
+++ b/stubs/src/lib.rs
@@ -125,11 +125,9 @@ mod tests {
                                         "time": 0
                                     },
                                     "playerName": "New callsign",
-                                    "groupName": "Group 1",
                                     "numberInGroup": 1,
                                     "heading": 0.5,
-                                    "speed": 0.8,
-                                    "category": 0
+                                    "speed": 0.8
                                 }
                             }
 		                },
@@ -165,11 +163,10 @@ mod tests {
                                 alt: 1.0,
                             }),
                             player_name: Some("New callsign".to_string()),
-                            group_name: "Group 1".to_string(),
+                            group: None,
                             number_in_group: 1,
                             heading: 0.5,
                             speed: 0.8,
-                            category: 0,
                         }))
                     }),
                     visibility: Some(event::mark_add_event::Visibility::Coalition(


### PR DESCRIPTION
When returning a unit object we will return the full group as its own
object instead of embedding some group attributes in the unit object.
This makes it easier for clients to parse streaming events without
having to make separate calls to get group information or require them
to keep a local copy in state that then needs to be managed.

Partly resolves https://github.com/DCS-gRPC/rust-server/issues/163