### PR TITLE
Fix blocking time percentage scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed error when retrieving mark panels (`WorldService.GetMarkPanels`) when the mark panel was created by a game master / JTAC, or when the player who created the mark panel left. `MarkPanel.initiator` is now optional. ([#156](https://github.com/DCS-gRPC/rust-server/issues/156))
+- Fixed scale of blocking time percentage in stats logs.
 
 ### Added
 - Added `SimulationFps` event that is fired every second and contains simulation fps information since the last event (i.e. for the past ~1sec).

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -148,7 +148,7 @@ impl Stats {
                         .unwrap_or(u64::MAX),
                 );
                 let block_time_total_percentage =
-                    block_time_total.as_secs_f64() / elapsed.as_secs_f64();
+                    (block_time_total.as_secs_f64() / elapsed.as_secs_f64()) * 100.0;
 
                 // average queue size
                 let queue_size_average = f64::try_from(interval_stats.queue_size_total)
@@ -167,7 +167,7 @@ impl Stats {
                     interval_stats.eps_highest
                 );
                 log::info!(
-                    "Blocking time: total={:?} (≙ {:.3}%)",
+                    "Blocking time: total={:?} (≙ {:.2}%)",
                     block_time_total,
                     block_time_total_percentage
                 );


### PR DESCRIPTION
The blocking time percentage needs to be multiplied by 100 to match the
% unit.