### PR TITLE
Convert scenery name to a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Unit objects now return the full group object in the `group` field to make event processing easier. This replaces the `group_name` and `group_category` fields and is a backwards incompatible change.
 - Updated all vectors to be in DCS' coordinate system (+x north, -x south, +z is east, -z west, +y up and -y down)
+- Scenery objects now have an `id` instead of a `name`, since dcs associates them with a number.
 
 ## [0.6.0] - 2022-05-30
 

--- a/lua/DCS-gRPC/exporters/object.lua
+++ b/lua/DCS-gRPC/exporters/object.lua
@@ -91,8 +91,8 @@ end
 
 GRPC.exporters.scenery = function(scenery)
   return {
+    id = tonumber(scenery:getName()),
     type = scenery:getTypeName(),
-    name = scenery:getName(),
     position = GRPC.exporters.position(scenery:getPoint()),
   }
 end
@@ -106,7 +106,7 @@ end
 -- https://wiki.hoggitworld.com/view/DCS_Class_Object
 GRPC.exporters.unknown = function(object)
   return {
-    name = object:getName(),
+    name = tostring(object:getName()),
   }
 end
 

--- a/protos/dcs/common/v0/common.proto
+++ b/protos/dcs/common/v0/common.proto
@@ -281,10 +281,10 @@ message Static {
  * An instance of a DCS scenery object
  */
 message Scenery {
+  // The id of the scenery
+  uint32 id = 1;
   // The DCS type-name of the scenery
-  string type = 1;
-  // The name of the scenery
-  string name = 2;
+  string type = 2;
   // The position of the scenery
   Position position = 3;
 }


### PR DESCRIPTION
When listening to Dead events, no events where triggered for scenery objects.
After looking at the logs I found out that the deserialization failed because
the scenery struct expected a string but a number was given.

Since I don't know if all scenery units have an integer as a name my idea
was to convert the integer to a string.

If scenery object names can only be numbers it would probably make more sense
to change the scenery struct to use an `uint`.