### PR TITLE
Apply cargo workspace inheritance to sub-crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "dcs-grpc-repl"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "clap",
  "dcs-grpc-stubs",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "dcs-grpc-stubs"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,29 @@
-[package]
-name = "dcs-grpc"
-version = "0.6.0"
-authors = ["Markus Ast <m@rkusa.st>"]
-license = "AGPL-3.0-or-later"
-edition = "2021"
-rust-version = "1.56"
-
 [workspace]
 members = [
   "repl",
   "stubs",
 ]
+
+[workspace.package]
+version = "0.6.0"
+license = "AGPL-3.0-or-later"
+authors = ["Markus Ast <m@rkusa.st>"]
+rust-version = "1.64"
+edition = "2021"
+
+[workspace.dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tonic = "0.8"
+thiserror = "1.0"
+
+[package]
+name = "dcs-grpc"
+version.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 
 [lib]
 crate-type = ["cdylib"]
@@ -25,14 +38,14 @@ log = "0.4"
 mlua = { version = "0.8", default-features = false, features = ["lua51", "module", "serialize"] }
 once_cell = "1.4.0"
 pin-project = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-stubs = { package = "dcs-grpc-stubs", version = "0.1", path = "./stubs", features = ["server"] }
-thiserror = "1.0"
+serde.workspace = true
+serde_json.workspace = true
+stubs = { package = "dcs-grpc-stubs", path = "./stubs", features = ["server"] }
+thiserror.workspace = true
 time = { version = "0.3", features = ["formatting", "parsing"] }
 tokio = { version = "1.0", features = ["rt-multi-thread", "time", "sync"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
-tonic = "0.8"
+tonic.workspace = true
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The following section is only applicable to people who want to developer the DCS
 
 ### Build Dependencies
 
-- Rust `>=1.56`
+- Rust `>=1.64`
 - `rustfmt` (`rustup component add rustfmt`)
 
 ### Build

--- a/repl/Cargo.toml
+++ b/repl/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "dcs-grpc-repl"
-version = "0.1.0"
-authors = ["Markus Ast <m@rkusa.st>"]
-license = "AGPL-3.0-or-later"
-edition = "2021"
-rust-version = "1.56"
+version.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 
 [dependencies]
 clap = { version = "3.0", features = ["derive"] }
-stubs = { package = "dcs-grpc-stubs", version = "0.1", path = "../stubs", features = ["client"] }
-serde_json = "1.0"
-thiserror = "1.0"
+stubs = { package = "dcs-grpc-stubs", path = "../stubs", features = ["client"] }
+serde_json.workspace = true
+thiserror.workspace = true
 tokio = { version = "1.0", features = ["rt-multi-thread"] }
-tonic = "0.8"
+tonic.workspace = true

--- a/stubs/Cargo.toml
+++ b/stubs/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
 name = "dcs-grpc-stubs"
-version = "0.1.0"
-authors = ["Markus Ast <m@rkusa.st>"]
-license = "AGPL-3.0-or-later"
-edition = "2021"
-rust-version = "1.56"
+version.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 
 [dependencies]
 prost = "0.11"
 prost-types = "0.11"
-serde = { version = "1.0", features = ["derive"] }
-tonic = "0.8"
+serde.workspace = true
+tonic.workspace = true
 
 [build-dependencies]
 tonic-build = "0.8"
 protoc-bundled = { git = "https://github.com/rkusa/protoc-bundled.git", rev = "3.21.6" }
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json.workspace = true
 
 [features]
 default = []


### PR DESCRIPTION
This PR makes use of [Rust 1.64's workspace inheritance](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html#cargo-improvements-workspace-inheritance-and-multi-target-builds). This allows sub-crates to inherit metadata (version, etc.) and dependencies.

Advantage:
- Easier to ensure all sub-crates use the same version of a common dependency
- By inheriting the version, we can not forgot to bump one of them upon release

Disadvantage:
- Bumps min Rust version to 1.64
