### PR TITLE
Add getDetectedTargets method to controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `SimulationFps` event that is fired every second and contains simulation fps information since the last event (i.e. for the past ~1sec).
 - Added `GetSessionId` API
+- Added `GetDetectedTargets` API. Method follows the DCS implementation of controller's getDetectedTargets. Can optionally also return the unit or weapon objects tracked by the radar.
 
 ### Changed
 - Unit objects now return the full group object in the `group` field to make event processing easier. This replaces the `group_name` and `group_category` fields and is a backwards incompatible change.

--- a/lua/DCS-gRPC/exporters/object.lua
+++ b/lua/DCS-gRPC/exporters/object.lua
@@ -24,19 +24,6 @@ GRPC.exporters.position = function(pos)
   }
 end
 
-GRPC.exporters.detectedTarget = function(contact)
-  return {
-    id = contact.id,
-    distance = contact.distance,
-    velocity = contact.velocity,
-    type = contact.type,
-    visible = contact.visible,
-    position = contact.position,
-    name = contact.name,
-    descriptor = contact.descriptor,
-  }
-end
-
 GRPC.exporters.unit = function(unit)
   local vector = unit:getVelocity()
 

--- a/lua/DCS-gRPC/exporters/object.lua
+++ b/lua/DCS-gRPC/exporters/object.lua
@@ -40,6 +40,7 @@ end
 GRPC.exporters.unit = function(unit)
   local vector = unit:getVelocity()
 
+---@diagnostic disable-next-line: deprecated
   local heading = math.deg(math.atan2(vector.z, vector.x))
   if heading < 0 then
     heading = heading + 360

--- a/lua/DCS-gRPC/exporters/object.lua
+++ b/lua/DCS-gRPC/exporters/object.lua
@@ -24,6 +24,19 @@ GRPC.exporters.position = function(pos)
   }
 end
 
+GRPC.exporters.detectedTarget = function(contact)
+  return {
+    id = contact.id,
+    distance = contact.distance,
+    velocity = contact.velocity,
+    type = contact.type,
+    visible = contact.visible,
+    position = contact.position,
+    name = contact.name,
+    descriptor = contact.descriptor,
+  }
+end
+
 GRPC.exporters.unit = function(unit)
   local vector = unit:getVelocity()
 

--- a/lua/DCS-gRPC/methods/controllers.lua
+++ b/lua/DCS-gRPC/methods/controllers.lua
@@ -51,37 +51,37 @@ GRPC.methods.getDetectedTargets = function(params)
   for i, contact in ipairs(targets) do
     local category = Object.getCategory(contact.object)
 
-    contact.id = contact.object.id_
-    contact.target = {}
-
-    if category == 1 then
-      contact.name = Unit.getName(contact.object)
-      contact.type = 1
-      if params.includeObject == true then
-        contact.unit = GRPC.exporters.unit( contact.object )
-      end
-    end
-    if category == 2 then
-      contact.name = Weapon.getName(contact.object)
-      contact.type = 2
-      if params.includeObject == true then
-        contact.weapon = GRPC.exporters.weapon( contact.object )
-      end
-    end
-
-    if contact.type == nil then
-      return GRPC.errorNotFound("Could not find target with id '" .. contact.object.id_ .. "' as a Unit or Weapon")
+    if category == nil then
+      return GRPC.errorNotFound("Could not find target with id '" .. contact.object:getID() .. "'")
     end
 
     local result = {
       distance = contact.distance,
-      name = tostring(contact.name),
-      id = contact.id,
-      type = contact.type,
+      id = contact.object.id_,
       visible = contact.visible,
-      unit = contact.unit,
-      weapon = contact.weapon,
+      target = {}
     }
+
+    --If target is a unit
+    if category == 1 then
+      if params.includeObject == true then
+        result.target.unit = GRPC.exporters.unit( contact.object )
+      else
+        result.target.basicInformation = {}
+        result.target.basicInformation.name = tostring( Unit.getName(contact.object) )
+        result.target.basicInformation.type = 1
+      end
+    end
+    --If target is a weapon
+    if category == 2 then
+      if params.includeObject == true then
+        result.target.weapon = GRPC.exporters.weapon( contact.object )
+      else
+        result.target.basicInformation = {}
+        result.target.basicInformation.name = tostring( Weapon.getName(contact.object) )
+        result.target.basicInformation.type = 2
+      end
+    end
 
     results[i] = result
   end

--- a/lua/DCS-gRPC/methods/controllers.lua
+++ b/lua/DCS-gRPC/methods/controllers.lua
@@ -50,7 +50,7 @@ GRPC.methods.getDetectedTargets = function(params)
 
   for i, contact in ipairs(targets) do
     contact.name = Unit.getName({["id_"] = contact.object.id_})
-    
+
     local contact_unit = Unit.getByName(contact.name)
 
     local descriptor
@@ -59,7 +59,7 @@ GRPC.methods.getDetectedTargets = function(params)
     end
 
     contact.id = tonumber(contact_unit:getID())
-    contact.descriptor = descriptor
+    contact.descriptors = descriptor
     contact.velocity = GRPC.exporters.vector(contact_unit:getVelocity())
     contact.position = GRPC.exporters.position(contact_unit:getPoint())
 

--- a/protos/dcs/common/v0/common.proto
+++ b/protos/dcs/common/v0/common.proto
@@ -256,32 +256,6 @@ message Weapon {
 }
 
 /**
- * An instance of a contact in a DCS AI controller's detection table
- *
- * This is a target that the AI controller has detected and is actively tracking
- *
- */
-
-message Contact {
-  // The contact's name
-  string name = 1;
-  // The DCS generated ID
-  uint32 id = 2;
-  // The contact's position
-  Position position = 3;
-  // The contact's velocity
-  Vector velocity = 4;
-  // The contact's descriptors
-  repeated string descriptors = 5;
-  // Can the sensor see the contact
-  bool visible = 6;
-  // Does the controller know the distance to the contact?
-  bool distance = 7;
-  // Does the controller know the unit type of the contact?
-  bool type = 8;
-}
-
-/**
  * An instance of a DCS static object
  *
  * These objects are often buildings but can also be vehicles that have no AI or
@@ -401,7 +375,7 @@ message MarkPanel {
   optional string text = 6;
   // The position of the mark.
   Position position = 7;
-}
+} 
 
 /**
  * A vector in a left-handed coordinate system with +z being north, -z south, +x
@@ -413,4 +387,27 @@ message Vector {
   double x = 1;
   double y = 2;
   double z = 3;
+}
+
+/**
+ * An instance of a contact in a DCS AI controller's detection table
+ *
+ * This is a target that the AI controller has detected and is actively tracking
+ *
+ */
+message Contact {
+  // The contact's name
+  string name = 1;
+  // The DCS generated ID
+  uint32 id = 2;
+  // Can the sensor see the contact
+  bool visible = 3;
+  // Does the controller know the distance to the contact?
+  bool distance = 4;
+  // The type of unit the contact is
+  uint32 type = 5;
+  // optional: The contact object
+  optional Unit unit = 6;
+  // optional: The contact object
+  optional Weapon weapon = 7;
 }

--- a/protos/dcs/common/v0/common.proto
+++ b/protos/dcs/common/v0/common.proto
@@ -272,7 +272,7 @@ message Contact {
   // The contact's velocity
   Vector velocity = 4;
   // The contact's descriptors
-  repeated string descriptor = 5;
+  repeated string descriptors = 5;
   // Can the sensor see the contact
   bool visible = 6;
   // Does the controller know the distance to the contact?

--- a/protos/dcs/common/v0/common.proto
+++ b/protos/dcs/common/v0/common.proto
@@ -396,14 +396,6 @@ message Vector {
  *
  */
 message Contact {
-  message BasicInformation {
-    // The contact's name
-    string name = 1;
-    // The type of unit the contact is
-    uint32 type = 2;
-    // optional: The contact object
-  }
-
   // The DCS generated ID
   uint32 id = 1;
   // Can the sensor see the contact
@@ -413,7 +405,7 @@ message Contact {
 
   // Either the basic information, or Unit or Weapon export object
   oneof target {
-    BasicInformation basic_information = 4;
+    Unknown object = 4;
     Unit unit = 5;
     Weapon weapon = 6;
   }

--- a/protos/dcs/common/v0/common.proto
+++ b/protos/dcs/common/v0/common.proto
@@ -256,6 +256,32 @@ message Weapon {
 }
 
 /**
+ * An instance of a contact in a DCS AI controller's detection table
+ *
+ * This is a target that the AI controller has detected and is actively tracking
+ *
+ */
+
+message Contact {
+  // The contact's name
+  string name = 1;
+  // The DCS generated ID
+  uint32 id = 2;
+  // The contact's position
+  Position position = 3;
+  // The contact's velocity
+  Vector velocity = 4;
+  // The contact's descriptors
+  repeated string descriptor = 5;
+  // Can the sensor see the contact
+  bool visible = 6;
+  // Does the controller know the distance to the contact?
+  bool distance = 7;
+  // Does the controller know the unit type of the contact?
+  bool type = 8;
+}
+
+/**
  * An instance of a DCS static object
  *
  * These objects are often buildings but can also be vehicles that have no AI or

--- a/protos/dcs/common/v0/common.proto
+++ b/protos/dcs/common/v0/common.proto
@@ -396,18 +396,25 @@ message Vector {
  *
  */
 message Contact {
-  // The contact's name
-  string name = 1;
+  message BasicInformation {
+    // The contact's name
+    string name = 1;
+    // The type of unit the contact is
+    uint32 type = 2;
+    // optional: The contact object
+  }
+
   // The DCS generated ID
-  uint32 id = 2;
+  uint32 id = 1;
   // Can the sensor see the contact
-  bool visible = 3;
+  bool visible = 2;
   // Does the controller know the distance to the contact?
-  bool distance = 4;
-  // The type of unit the contact is
-  uint32 type = 5;
-  // optional: The contact object
-  optional Unit unit = 6;
-  // optional: The contact object
-  optional Weapon weapon = 7;
+  bool distance = 3;
+
+  // Either the basic information, or Unit or Weapon export object
+  oneof target {
+    BasicInformation basic_information = 4;
+    Unit unit = 5;
+    Weapon weapon = 6;
+  }
 }

--- a/protos/dcs/common/v0/common.proto
+++ b/protos/dcs/common/v0/common.proto
@@ -375,7 +375,7 @@ message MarkPanel {
   optional string text = 6;
   // The position of the mark.
   Position position = 7;
-} 
+}
 
 /**
  * A vector in a left-handed coordinate system with +z being north, -z south, +x

--- a/protos/dcs/controller/v0/controller.proto
+++ b/protos/dcs/controller/v0/controller.proto
@@ -1,16 +1,16 @@
 syntax = "proto3";
 package dcs.controller.v0;
+import "dcs/common/v0/common.proto";
 option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Controller";
 option go_package = "github.com/DCS-gRPC/go-bindings/dcs/v0/controller";
-
-import "dcs/common/v0/common.proto";
 
 service ControllerService {
   // https://wiki.hoggitworld.com/view/DCS_option_alarmState
   rpc SetAlarmState(SetAlarmStateRequest) returns (SetAlarmStateResponse) {}
 
   // https://wiki.hoggitworld.com/view/DCS_func_getDetectedTargets
-  rpc GetDetectedTargets(GetDetectedTargetsRequest) returns (GetDetectedTargetsResponse) {}
+  rpc GetDetectedTargets(GetDetectedTargetsRequest) 
+    returns (GetDetectedTargetsResponse) {}
 }
 
 message SetAlarmStateRequest {

--- a/protos/dcs/controller/v0/controller.proto
+++ b/protos/dcs/controller/v0/controller.proto
@@ -3,9 +3,14 @@ package dcs.controller.v0;
 option csharp_namespace = "RurouniJones.Dcs.Grpc.V0.Controller";
 option go_package = "github.com/DCS-gRPC/go-bindings/dcs/v0/controller";
 
+import "dcs/common/v0/common.proto";
+
 service ControllerService {
   // https://wiki.hoggitworld.com/view/DCS_option_alarmState
   rpc SetAlarmState(SetAlarmStateRequest) returns (SetAlarmStateResponse) {}
+
+  // https://wiki.hoggitworld.com/view/DCS_func_getDetectedTargets
+  rpc GetDetectedTargets(GetDetectedTargetsRequest) returns (GetDetectedTargetsResponse) {}
 }
 
 message SetAlarmStateRequest {
@@ -24,4 +29,13 @@ message SetAlarmStateRequest {
 }
 
 message SetAlarmStateResponse {
+}
+
+message GetDetectedTargetsRequest {
+  string unit_name = 1;
+  optional bool include_descriptors = 2;
+}
+
+message GetDetectedTargetsResponse {
+  repeated dcs.common.v0.Contact contacts = 1; 
 }

--- a/protos/dcs/controller/v0/controller.proto
+++ b/protos/dcs/controller/v0/controller.proto
@@ -33,7 +33,7 @@ message SetAlarmStateResponse {
 
 message GetDetectedTargetsRequest {
   string unit_name = 1;
-  optional bool include_descriptors = 2;
+  optional bool include_object = 2;
 }
 
 message GetDetectedTargetsResponse {

--- a/protos/dcs/controller/v0/controller.proto
+++ b/protos/dcs/controller/v0/controller.proto
@@ -32,8 +32,18 @@ message SetAlarmStateResponse {
 }
 
 message GetDetectedTargetsRequest {
+  enum DetectionType {
+    DETECTION_TYPE_UNSPECIFIED = 0;
+    DETECTION_TYPE_VISUAL = 1;
+    DETECTION_TYPE_OPTIC = 2;
+    DETECTION_TYPE_RADAR = 4;
+    DETECTION_TYPE_IRST = 8;
+    DETECTION_TYPE_RWR = 16;
+    DETECTION_TYPE_DLINK = 32;
+  }
   string unit_name = 1;
   optional bool include_object = 2;
+  optional DetectionType detection_type = 3;
 }
 
 message GetDetectedTargetsResponse {

--- a/src/rpc/controller.rs
+++ b/src/rpc/controller.rs
@@ -12,4 +12,11 @@ impl ControllerService for MissionRpc {
         let res = self.request("setAlarmState", request).await?;
         Ok(Response::new(res))
     }
+    async fn get_detected_targets(
+        &self,
+        request: Request<controller::v0::GetDetectedTargetsRequest>,
+    ) -> Result<Response<controller::v0::GetDetectedTargetsResponse>, Status> {
+        let res = self.request("getDetectedTargets", request).await?;
+        Ok(Response::new(res))
+    }
 }


### PR DESCRIPTION
Created GRPC.methods.getDetectedTargets which returns target name, target type, visible (to the radar), distance (true if known by the radar), and optionally the unit or weapon object.

Created exporter for detectedTarget.

Added GetDetectedTargets rpc call to the controller service.

Added GetDetectedTargetsRequest and Response message.

controller proto now imports common proto.

Defined common Contact proto message
