### PR TITLE
Add unit id to GetTransform response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GetRealTime` API
 - Added `orientation` and `velocity` to `Weapon` object
 - Added DCS `time` of the update to units stream (`StreamUnitsResponse`)
+- Added `id` to `GetTransform` response
 
 ### Changed
 - Unit objects now return the full group object in the `group` field to make event processing easier. This replaces the `group_name` and `group_category` fields and is a backwards incompatible change.

--- a/lua/DCS-gRPC/methods/unit.lua
+++ b/lua/DCS-gRPC/methods/unit.lua
@@ -68,6 +68,7 @@ GRPC.methods.getUnitTransform = function(params)
 
   return GRPC.success({
     time = timer.getTime(),
+    id = tonumber(unit:getID()),
     rawTransform = GRPC.exporters.rawTransform(unit),
   })
 end

--- a/protos/dcs/unit/v0/unit.proto
+++ b/protos/dcs/unit/v0/unit.proto
@@ -60,6 +60,9 @@ message GetTransformResponse {
   dcs.common.v0.Orientation orientation = 3;
   // The velocity of the unit in both 2D and 3D space
   dcs.common.v0.Velocity velocity = 4;
+  // The DCS generated ID for the unit. Useful to detect if the underlying unit
+  // for the transform changed (could be a respawned unit with the same name).
+  uint32 id = 5;
 }
 
 message GetPlayerNameRequest {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -303,6 +303,7 @@ impl UnitState {
         .await?;
         let GetTransformResponse {
             time,
+            id: _,
             position,
             orientation,
             velocity,

--- a/stubs/src/unit.rs
+++ b/stubs/src/unit.rs
@@ -7,6 +7,7 @@ pub mod v0 {
     #[serde(rename_all = "camelCase")]
     struct GetTransformResponseIntermediate {
         time: f64,
+        id: u32,
         raw_transform: Option<RawTransform>,
     }
 
@@ -14,11 +15,13 @@ pub mod v0 {
         fn from(i: GetTransformResponseIntermediate) -> Self {
             let GetTransformResponseIntermediate {
                 time,
+                id,
                 raw_transform,
             } = i;
             let transform = Transform::from(raw_transform.unwrap_or_default());
             GetTransformResponse {
                 time,
+                id,
                 position: Some(transform.position),
                 orientation: Some(transform.orientation),
                 velocity: Some(transform.velocity),


### PR DESCRIPTION
For the [LSO bot](https://github.com/DCS-gRPC/lso), I frequently poll carrier-plane pairs for their transform using the `GetTransform` method. This has the shortcoming, since I query the units by name, that I cannot easily detect whether a unit respawned. It could easily be that a client reselects the same slot over and over again (in between my polling calls), and since the unit name isn't changing, I cannot tell that the underlying unit changed. The easiest solution I could come up with is to include the unit id in the response, so that I can compare the ids between calls to detect a new unit behind the queried name.