### PR TITLE
Add `GetBallisticsCount` API.

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -21,5 +21,6 @@ read_globals = {
   "trigger",
   "Unit",
   "world",
-  "missionCommands"
+  "missionCommands",
+  "Export"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GetRealTime` API
 - Added `orientation` and `velocity` to `Weapon` object
 - Added DCS `time` of the update to units stream (`StreamUnitsResponse`)
+- Added `GetBallisticsCount` API
 
 ### Changed
 - Unit objects now return the full group object in the `group` field to make event processing easier. This replaces the `group_name` and `group_category` fields and is a backwards incompatible change.

--- a/lua/DCS-gRPC/methods/hook.lua
+++ b/lua/DCS-gRPC/methods/hook.lua
@@ -6,6 +6,7 @@
 local DCS = DCS
 local GRPC = GRPC
 local net = net
+local Export = Export
 
 GRPC.methods.getMissionName = function()
   return GRPC.success({name = DCS.getMissionName()})
@@ -123,3 +124,11 @@ GRPC.methods.getRealTime = function()
   -- https://wiki.hoggitworld.com/view/DCS_func_getRealTime
   return GRPC.success({time = DCS.getRealTime()})
 end
+
+GRPC.methods.getBallisticsCount = function()
+  local ballistics = Export.LoGetWorldObjects("ballistic")
+  local count = 0
+  for _ in pairs(ballistics) do count = count + 1 end
+  return GRPC.success({count = count})
+end
+

--- a/protos/dcs/hook/v0/hook.proto
+++ b/protos/dcs/hook/v0/hook.proto
@@ -68,6 +68,10 @@ service HookService {
 
   // https://wiki.hoggitworld.com/view/DCS_func_getRealTime
   rpc GetRealTime(GetRealTimeRequest) returns (GetRealTimeResponse) {}
+
+  // Get a count of ballistics objects
+  rpc GetBallisticsCount(GetBallisticsCountRequest)
+    returns (GetBallisticsCountResponse) {}
 }
 
 message GetMissionNameRequest {
@@ -225,4 +229,11 @@ message GetRealTimeRequest {
 message GetRealTimeResponse {
   // The current time in a mission relative to the DCS start time
   double time = 1;
+}
+
+message GetBallisticsCountRequest {
+}
+
+message GetBallisticsCountResponse {
+  uint32 count = 1;
 }

--- a/src/rpc/hook.rs
+++ b/src/rpc/hook.rs
@@ -152,4 +152,12 @@ impl HookService for HookRpc {
         let res = self.request("getRealTime", request).await?;
         Ok(Response::new(res))
     }
+
+    async fn get_ballistics_count(
+        &self,
+        request: Request<hook::v0::GetBallisticsCountRequest>,
+    ) -> Result<Response<hook::v0::GetBallisticsCountResponse>, Status> {
+        let res = self.request("getBallisticsCount", request).await?;
+        Ok(Response::new(res))
+    }
 }


### PR DESCRIPTION
Add an API that allows us to count all ballistics objects.

# Note

I am not entirely sure if this is the best way to do it vs having a ballistics count be part of the event stream on a timer but it works and has already fulfilled a [useful purpose](https://forum.dcs.world/topic/308247-invalid-ballistics-objects-being-created-and-not-cleaned-up-resulting-in-fps-impact/page/2/#comment-5095416) so adding it in its current state.