### PR TITLE
Add GRPC.tts(...) Lua API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added DCS `time` of the update to units stream (`StreamUnitsResponse`)
 - Added `GetBallisticsCount` API
 - Added `TtsService/Transmit` to synthesize text to speech and transmit it over SRS
+- Added `GRPC.tts(ssml, frequency[, options])` Lua API
 
 ### Changed
 - Unit objects now return the full group object in the `group` field to make event processing easier. This replaces the `group_name` and `group_category` fields and is a backwards incompatible change.

--- a/README.md
+++ b/README.md
@@ -163,6 +163,45 @@ You can also check for the present of a `\Logs\grpc.log` file.
 
 The server will be running on port 50051 by default.
 
+## Lua API
+
+`DCS-gRPC` provides the following Lua APIs to interact with the server from within Lua.
+
+- `GRPC.tts(ssml, frequency[, options])` - Synthesize text (`ssml`; SSML tags supported) to speech and transmit it over SRS on the `frequency` with the following optional `options` (and their defaults):
+    ```lua
+    {
+        -- The plain text without any transformations made to it for the purpose of getting it spoken out
+        -- as desired (no SSML tags, no FOUR NINER instead of 49, ...). Even though this field is
+        -- optional, please consider providing it as it can be used to display the spoken text to players
+        -- with hearing impairments.
+        plaintext = null, -- e.g. `= "Hello Pilot"`
+
+        -- Name of the SRS client.
+        srsClientName = "DCS-gRPC",
+
+        -- The origin of the transmission. Relevant if the SRS server has "Line of
+        -- Sight" and/or "Distance Limit" enabled.
+        position = {
+            lat = 0.0,
+            lon = 0.0,
+            alt = 0.0, -- in meters
+        },
+
+        -- The coalition of the transmission. Relevant if the SRS server has "Secure
+        -- Coalition Radios" enabled. Supported values are: `blue` and `red`. Defaults
+        -- to being spectator if not specified.
+        coalition = null,
+
+        -- TTS provider to be use. Defaults to the one configured in your config or to Windows'
+        -- built-in TTS. Examples:
+        -- `= { aws = {} }` / `= { aws = { voice = "..." } }` enable AWS TTS
+        -- `= { azure = {} }` / `= { azure = { voice = "..." } }` enable Azure TTS
+        -- `= { gcloud = {} }` / `= { gcloud = { voice = "..." } }` enable Google Cloud TTS
+        -- `= { win = {} }` / `= { win = { voice = "..." } }` enable Windows TTS
+        provider = null,
+    }
+    ```
+
 ## Client Development
 
 `DCS-gRPC`, as the name implies, uses the [gRPC](https://grpc.io/) framework to handle communication between clients

--- a/lua/DCS-gRPC/grpc.lua
+++ b/lua/DCS-gRPC/grpc.lua
@@ -47,6 +47,11 @@ GRPC.error = function(msg)
 end
 
 --
+-- APIs exposed to Lua
+--
+GRPC.tts = grpc.tts
+
+--
 -- Logging methods
 --
 

--- a/protos/dcs/tts/v0/tts.proto
+++ b/protos/dcs/tts/v0/tts.proto
@@ -34,11 +34,11 @@ message TransmitRequest {
 
   // The origin of the transmission. Relevant if the SRS server has "Line of
   // Sight" and/or "Distance Limit" enabled.
-  dcs.common.v0.Position position = 5;
+  Position position = 5;
 
   // The coalition of the transmission. Relevant if the SRS server has "Secure
   // Coalition Radios" enabled. Only Blue and Red are supported, all other
-  // values will fallback to Blue.
+  // values will fallback to Spectator.
   dcs.common.v0.Coalition coalition = 6;
 
   // Whether to keep the request open until the whole transmission was sent. If
@@ -85,4 +85,22 @@ message TransmitRequest {
 message TransmitResponse {
   // The duration in milliseconds it roughly takes to speak the transmission.
   uint32 duration_ms = 1;
+}
+
+/**
+ * Position of an object in DCS
+ *
+ * Latitude and Longitude are in Decimal Degrees format (e.g. 41.33 / 37.21).
+ * Negative values are used for West of the meridian and south of the equator
+ *
+ * Altitude is given in meters above Mean Sea Level (MSL) and can be a decimal
+ * value.
+ */
+message Position {
+  // Latitude in Decimal Degrees format
+  double lat = 1;
+  // Longitude in Decimal Degrees format
+  double lon = 2;
+  // Altitude in Meters above Mean Sea Level (MSL)
+  double alt = 3;
 }

--- a/src/hot_reload.rs
+++ b/src/hot_reload.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use std::{error, fmt};
 
+use crate::server::TtsOptions;
 use crate::Config;
 use libloading::{Library, Symbol};
 use mlua::prelude::*;
@@ -56,6 +57,18 @@ pub fn next(lua: &Lua, arg: (i32, Function)) -> LuaResult<bool> {
         f(lua, arg).map_err(take_error_ownership)
     } else {
         Ok(false)
+    }
+}
+
+pub fn tts(lua: &Lua, arg: (String, u64, Option<TtsOptions>)) -> LuaResult<()> {
+    if let Some(ref lib) = *LIBRARY.read().unwrap() {
+        let f: Symbol<fn(lua: &Lua, arg: (String, u64, Option<TtsOptions>)) -> LuaResult<()>> = unsafe {
+            lib.get(b"tts")
+                .map_err(|err| mlua::Error::ExternalError(Arc::new(err)))?
+        };
+        f(lua, arg).map_err(take_error_ownership)
+    } else {
+        Ok(())
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,6 @@
 use std::future::Future;
 use std::net::SocketAddr;
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::config::{Config, SrsConfig, TtsConfig};
@@ -19,7 +20,7 @@ use stubs::mission::v0::StreamEventsResponse;
 use stubs::net::v0::net_service_server::NetServiceServer;
 use stubs::timer::v0::timer_service_server::TimerServiceServer;
 use stubs::trigger::v0::trigger_service_server::TriggerServiceServer;
-use stubs::tts::v0::tts_service_server::TtsServiceServer;
+use stubs::tts::v0::tts_service_server::{TtsService, TtsServiceServer};
 use stubs::unit::v0::unit_service_server::UnitServiceServer;
 use stubs::world::v0::world_service_server::WorldServiceServer;
 use tokio::runtime::Runtime;
@@ -32,6 +33,7 @@ pub struct Server {
     shutdown: Shutdown,
     after_shutdown: Option<oneshot::Sender<()>>,
     state: ServerState,
+    tts: Arc<Tts>,
 }
 
 #[derive(Clone)]
@@ -57,12 +59,18 @@ impl Server {
             state: ServerState {
                 addr: format!("{}:{}", config.host, config.port).parse()?,
                 eval_enabled: config.eval_enabled,
-                ipc_mission,
+                ipc_mission: ipc_mission.clone(),
                 ipc_hook,
                 stats: Stats::new(shutdown.handle()),
                 tts_config: config.tts.clone().unwrap_or_default(),
                 srs_config: config.srs.clone().unwrap_or_default(),
             },
+            tts: Arc::new(Tts::new(
+                config.tts.clone().unwrap_or_default(),
+                config.srs.clone().unwrap_or_default(),
+                ipc_mission,
+                shutdown.handle(),
+            )),
             shutdown,
         })
     }
@@ -118,6 +126,46 @@ impl Server {
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
         self.runtime.block_on(future)
     }
+
+    pub fn tts(&self, ssml: String, frequency: u64, opts: Option<TtsOptions>) {
+        let tts = self.tts.clone();
+        let opts = opts.unwrap_or_default();
+        log::debug!("TTS from Lua: `{}` @ {} ({:?})", ssml, frequency, opts);
+
+        self.runtime.spawn(async move {
+            let result = tts
+                .transmit(tonic::Request::new(stubs::tts::v0::TransmitRequest {
+                    ssml,
+                    plaintext: opts.plaintext,
+                    frequency,
+                    srs_client_name: opts.srs_client_name,
+                    position: opts.position,
+                    coalition: opts
+                        .coalition
+                        .unwrap_or(stubs::common::v0::Coalition::Neutral)
+                        .into(),
+                    r#async: false,
+                    provider: opts.provider,
+                }))
+                .await;
+            match result {
+                Ok(_) => {}
+                Err(err) => {
+                    log::error!("Error in TTS transmission from Lua: {}", err);
+                }
+            }
+        });
+    }
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TtsOptions {
+    plaintext: Option<String>,
+    srs_client_name: Option<String>,
+    position: Option<stubs::tts::v0::Position>,
+    coalition: Option<stubs::common::v0::Coalition>,
+    provider: Option<stubs::tts::v0::transmit_request::Provider>,
 }
 
 async fn run(
@@ -196,4 +244,12 @@ pub enum StartError {
     Io(#[from] std::io::Error),
     #[error(transparent)]
     AddrParse(#[from] std::net::AddrParseError),
+}
+
+impl<'lua> mlua::FromLua<'lua> for TtsOptions {
+    fn from_lua(lua_value: mlua::Value<'lua>, lua: &'lua mlua::Lua) -> mlua::Result<Self> {
+        use mlua::LuaSerdeExt;
+        let opts: TtsOptions = lua.from_value(lua_value)?;
+        Ok(opts)
+    }
 }


### PR DESCRIPTION
Add `GRPC.tts(ssml, frequency[, options])` Lua API.

Usage: https://github.com/DCS-gRPC/rust-server/tree/tts-lua#lua-api

The API currently does not provide an means to prevent overlapping transmissions as we don't want to block the mission env when the API is called and because there is no safe way to return the transmission play time back to Lua asynchronously. I'd suggest to solve this via #200 in future.