### PR TITLE
Fix marker{Add,Change,Remove} position reporting (#219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `ActivateGroup` API which allows to activate groups with late activation.
 - Added `DestroyGroup` API which removes the entire group from the game world.
 - `DestroyUnit` API
+- Fixed `MarkAddEvent`, `MarkChangeEvent` and `MarkRemoveEvent` position
 
 ## [0.7.1] - 2023-01-08
 

--- a/lua/DCS-gRPC/methods/mission.lua
+++ b/lua/DCS-gRPC/methods/mission.lua
@@ -282,7 +282,7 @@ GRPC.onDcsEvent = function(event)
       type = "markAdd",
       initiator = {initiator = typed_exporter(event.initiator)},
       id = event.idx,
-      pos = GRPC.exporters.position(event.pos),
+      position = GRPC.exporters.position(event.pos),
       text = event.text,
     }
     if event.groupID > -1 and event.groupID then
@@ -300,7 +300,7 @@ GRPC.onDcsEvent = function(event)
       type = "markChange",
       initiator = {initiator = typed_exporter(event.initiator)},
       id = event.idx,
-      pos = GRPC.exporters.position(event.pos),
+      position = GRPC.exporters.position(event.pos),
       text = event.text,
     }
     if event.groupID > -1 and event.groupID then
@@ -318,7 +318,7 @@ GRPC.onDcsEvent = function(event)
       type = "markRemove",
       initiator = {initiator = typed_exporter(event.initiator)},
       id = event.idx,
-      pos = GRPC.exporters.position(event.pos),
+      position = GRPC.exporters.position(event.pos),
       text = event.text,
     }
     if event.groupID > -1 and event.groupID then


### PR DESCRIPTION
Whilst the DCS event returns "pos", the StreamEventsResponse proto for MarkAddEvent / MarkChangeEvent and MarkRemoveEvent expects position and so it is ignored.

This update resolves this by exposing the expected key

Before:
```
2023-04-02 12:52:10.967 DEBUG   dcs_grpc: Received event: StreamEventsResponse {
    time: 43333.0,
    event: Some(
        MarkAdd(
            MarkAddEvent {
                initiator: Some(
                    Initiator {
                        initiator: None,
                    },
                ),
                id: 251658265,
                position: None,
                text: "",
                visibility: Some(
                    Coalition(
                        Blue,
                    ),
                ),
            },
        ),
    ),
}
```

After:

```
2023-04-02 12:48:47.050 DEBUG   dcs_grpc: Received event: StreamEventsResponse {
    time: 43219.0,
    event: Some(
        MarkAdd(
            MarkAddEvent {
                initiator: Some(
                    Initiator {
                        initiator: None,
                    },
                ),
                id: 251658264,
                position: Some(
                    Position {
                        lat: 42.378214171188475,
                        lon: 41.691552100599964,
                        alt: 6.4470696449279785,
                        u: 616265.8744420735,
                        v: -269603.17429513455,
                    },
                ),
                text: "",
                visibility: Some(
                    Coalition(
                        Blue,
                    ),
                ),
            },
        ),
    ),
}
```