### PR TITLE
Fix crash of concurrent Win TTS synthesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `ActivateGroup` API which allows to activate groups with late activation.
 - Added `DestroyGroup` API which removes the entire group from the game world.
 - `DestroyUnit` API
+
+### Fixed
 - Fixed `MarkAddEvent`, `MarkChangeEvent` and `MarkRemoveEvent` position
+- Fixed crash of concurrent Windows TTS synthesis ([#223](https://github.com/DCS-gRPC/rust-server/issues/223))
 
 ## [0.7.1] - 2023-01-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2036,6 +2036,7 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = { version = "1.24", features = ["rt-multi-thread", "io-util", "net", "sync", "time"] }
+tokio = { version = "1.24", features = ["rt-multi-thread", "io-util", "net", "sync", "time", "parking_lot"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tonic = "0.8"
 


### PR DESCRIPTION
Fixes a crash related to Windows' TTS as reported [in Discord](https://discord.com/channels/696721363276267590/962651858760003594/1087405074373955675). This seems to be caused by a certain concurrency of the synthesis. I don't really know the exact cause (could be Windows - Rust interop), but simply preventing concurrency seems to fix it.

