### PR TITLE
Add Coqui (server) as TTS provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `ActivateGroup` API which allows to activate groups with late activation.
 - Added `DestroyGroup` API which removes the entire group from the game world.
 - Added `DestroyUnit` API
-- Added `GetClients` to `SrsService`, which retrieves a list of units that are connected to SRS and the frequencies they are connected to.
-- Added `SrsConnectEvent` and `SrsDisconnectEvent` events 
+- Added `GetClients` to `SrsService`, which retrieves a list of units that are connected to SRS and the frequencies they are connected to
+- Added `SrsConnectEvent` and `SrsDisconnectEvent` events
+- Added [Coqui](https://github.com/coqui-ai/TTS) as another TTS provider (that can be run locally)
 
 ### Fixed
 - Fixed `MarkAddEvent`, `MarkChangeEvent` and `MarkRemoveEvent` position

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,28 +45,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
-name = "async-stream"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.22",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,7 +429,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "windows 0.40.0",
+ "windows",
 ]
 
 [[package]]
@@ -889,7 +867,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows 0.48.0",
+ "windows",
 ]
 
 [[package]]
@@ -2189,14 +2167,13 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.3"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
- "async-stream",
  "async-trait",
  "axum",
- "base64 0.13.1",
+ "base64 0.21.2",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2208,22 +2185,19 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "prost-derive",
  "tokio",
  "tokio-stream",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
 name = "tonic-build"
-version = "0.8.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
+checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -2294,16 +2268,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]
@@ -2559,21 +2523,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e30acc718a52fb130fec72b1cb5f55ffeeec9253e1b785e94db222178a6acaa1"
-dependencies = [
- "windows_aarch64_gnullvm 0.40.0",
- "windows_aarch64_msvc 0.40.0",
- "windows_i686_gnu 0.40.0",
- "windows_i686_msvc 0.40.0",
- "windows_x86_64_gnu 0.40.0",
- "windows_x86_64_gnullvm 0.40.0",
- "windows_x86_64_msvc 0.40.0",
-]
-
-[[package]]
-name = "windows"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
@@ -2622,12 +2571,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3caa4a1a16561b714323ca6b0817403738583033a6a92e04c5d10d4ba37ca10"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
@@ -2637,12 +2580,6 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328973c62dfcc50fb1aaa8e7100676e0b642fe56bac6bafff3327902db843ab4"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2658,12 +2595,6 @@ checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa5b09fad70f0df85dea2ac2a525537e415e2bf63ee31cf9b8e263645ee9f3c1"
-
-[[package]]
-name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
@@ -2673,12 +2604,6 @@ name = "windows_i686_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a1ad4031c1a98491fa195d8d43d7489cb749f135f2e5c4eed58da094bd0d876"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2694,12 +2619,6 @@ checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520ff37edd72da8064b49d2281182898e17f0688ae9f4070bca27e4b5c162ac7"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
@@ -2712,12 +2631,6 @@ checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046e5b82215102c44fd75f488f1b9158973d02aa34d06ed85c23d6f5520a2853"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
@@ -2727,12 +2640,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0c9c6df55dd1bfa76e131cef44bdd8ec9c819ef3611f04dfe453fd5bfeda28"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,6 +422,7 @@ dependencies = [
  "log",
  "ogg",
  "reqwest",
+ "rubato",
  "rusoto_core",
  "rusoto_credential",
  "rusoto_polly",
@@ -1128,6 +1129,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "num-complex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1312,6 +1332,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primal-check"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df7f93fd637f083201473dab4fee2db4c429d32e55e3299980ab3957ab916a0"
+dependencies = [
+ "num-integer",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1443,6 +1472,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "realfft"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953d9f7e5cdd80963547b456251296efc2626ed4e3cbf36c869d9564e0220571"
+dependencies = [
+ "rustfft",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,6 +1576,18 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rubato"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4191a1456beb356999454c55cf94fe6a64400dd15ee5c21ee0df88845b667fa4"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "realfft",
 ]
 
 [[package]]
@@ -1643,6 +1693,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustfft"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17d4f6cbdb180c9f4b2a26bbf01c4e647f1e1dea22fe8eb9db54198b32f9434"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
+ "version_check",
 ]
 
 [[package]]
@@ -1923,6 +1988,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "strsim"
@@ -2268,6 +2339,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6522d49d03727ffb138ae4cbc1283d3774f0d10aa7f9bf52e6784c45daf9b23"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.24", features = ["rt-multi-thread", "io-util", "net", "sync", "time", "parking_lot", "macros"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
-tonic = "0.8"
+tonic = "0.9"
 
 [package]
 name = "dcs-grpc"

--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ tts.provider.aws.region = "eu-central-1"
 -- The default AWS voice to use (see https://docs.aws.amazon.com/polly/latest/dg/voicelist.html).
 tts.provider.aws.defaultVoice = "Brian"
 
+-- The address your Coqui server is running at.
+tts.provider.coqui.addr = "http://localhost:4000"
+
+-- The voice (speaker id) to be used from the active model (default of `p250` assumes that you are
+-- running `tts_models/en/vctk/vits`).
+tts.provider.coqui.voice = "p250"
+
 -- Your Google Cloudd access key.
 tts.provider.gcloud.key = "..."
 
@@ -166,6 +173,16 @@ To confirm that the server is running check the `\Logs\dcs.log` file and look fo
 You can also check for the present of a `\Logs\grpc.log` file.
 
 The server will be running on port 50051 by default.
+
+### Use Coqui for TTS
+
+[Coqui](https://github.com/coqui-ai/TTS) is written in Python and can thus not be directly integrated into DCS-gRPC. This is why you have to run Coqui as a server yourself and point DCS-gRPC to it. The easiest way to run it is using Docker (via [Docker for Windows](https://docs.docker.com/desktop/install/windows-install/)):
+
+```bash
+docker run --rm -it -p 4000:5002 \
+  --entrypoint python3 ghcr.io/coqui-ai/tts-cpu TTS/server/server.py \
+  --model_name tts_models/en/vctk/vits
+```
 
 ## Lua API
 

--- a/protos/dcs/srs/v0/srs.proto
+++ b/protos/dcs/srs/v0/srs.proto
@@ -64,6 +64,11 @@ message TransmitRequest {
     optional string voice = 1;
   }
 
+  message Coqui {
+    // The voice (speaker id) of the model your Coqui server is running.
+    optional string voice = 1;
+  }
+
   message GCloud {
     // The voice the text is synthesized in, see:
     // https://cloud.google.com/text-to-speech/docs/voices
@@ -82,6 +87,7 @@ message TransmitRequest {
     Azure azure = 9;
     GCloud gcloud = 10;
     Windows win = 11;
+    Coqui coqui = 12;
   }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,7 @@ pub struct TtsConfig {
 pub struct TtsProviderConfig {
     pub aws: Option<AwsConfig>,
     pub azure: Option<AzureConfig>,
+    pub coqui: Option<CoquiConfig>,
     pub gcloud: Option<GCloudConfig>,
     pub win: Option<WinConfig>,
 }
@@ -45,6 +46,7 @@ pub struct TtsProviderConfig {
 pub enum TtsProvider {
     Aws,
     Azure,
+    Coqui,
     GCloud,
     #[default]
     Win,
@@ -65,6 +67,13 @@ pub struct AzureConfig {
     pub key: Option<String>,
     pub region: Option<String>,
     pub default_voice: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CoquiConfig {
+    pub addr: Option<String>,
+    pub voice: Option<String>,
 }
 
 #[derive(Clone, Deserialize, Serialize)]

--- a/src/rpc/srs.rs
+++ b/src/rpc/srs.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use ::srs::Sender;
 #[cfg(target_os = "windows")]
 use ::tts::WinConfig;
-use ::tts::{AwsConfig, AwsRegion, AzureConfig, GCloudConfig, TtsConfig};
+use ::tts::{AwsConfig, AwsRegion, AzureConfig, CoquiConfig, GCloudConfig, TtsConfig};
 use futures_util::FutureExt;
 use stubs::common::v0::{Coalition, Unit};
 use stubs::mission::v0::stream_events_response::{Event, TtsEvent};
@@ -99,6 +99,9 @@ impl SrsService for Srs {
                 TtsProvider::Azure => {
                     transmit_request::Provider::Azure(transmit_request::Azure { voice: None })
                 }
+                TtsProvider::Coqui => {
+                    transmit_request::Provider::Coqui(transmit_request::Coqui { voice: None })
+                }
                 TtsProvider::GCloud => {
                     transmit_request::Provider::Gcloud(transmit_request::GCloud { voice: None })
                 }
@@ -175,6 +178,23 @@ impl SrsService for Srs {
                         .ok_or_else(|| {
                             Status::failed_precondition("tts.provider.azure.region config not set")
                         })?,
+                })
+            }
+            transmit_request::Provider::Coqui(transmit_request::Coqui { voice }) => {
+                TtsConfig::Coqui(CoquiConfig {
+                    addr: self
+                        .tts_config
+                        .provider
+                        .as_ref()
+                        .and_then(|p| p.coqui.as_ref())
+                        .and_then(|p| p.addr.clone()),
+                    voice: voice.or_else(|| {
+                        self.tts_config
+                            .provider
+                            .as_ref()
+                            .and_then(|p| p.coqui.as_ref())
+                            .and_then(|p| p.voice.clone())
+                    }),
                 })
             }
             transmit_request::Provider::Gcloud(transmit_request::GCloud { voice }) => {

--- a/src/srs.rs
+++ b/src/srs.rs
@@ -91,7 +91,6 @@ async fn run(
         else {
             continue;
         };
-        log::info!("srs msg: {msg:#?}");
 
         match msg {
             Message::Sync(SyncMessage {
@@ -236,10 +235,7 @@ async fn connected(
             Ok(unit) => unit,
             Err(err) => {
                 if err.code() != Code::NotFound {
-                    log::error!(
-                        "failed to get unit by id for srs connect event: {}",
-                        err
-                    );
+                    log::error!("failed to get unit by id for srs connect event: {}", err);
                 }
                 return None;
             }
@@ -271,10 +267,7 @@ async fn disconnected(
             Ok(unit) => unit,
             Err(err) => {
                 if err.code() != Code::NotFound {
-                    log::error!(
-                        "failed to get unit by id for srs disconnect event: {}",
-                        err
-                    );
+                    log::error!("failed to get unit by id for srs disconnect event: {}", err);
                 }
                 return None;
             }

--- a/stubs/Cargo.toml
+++ b/stubs/Cargo.toml
@@ -13,7 +13,7 @@ serde.workspace = true
 tonic.workspace = true
 
 [build-dependencies]
-tonic-build = "0.8"
+tonic-build = "0.9"
 protoc-bundled = { git = "https://github.com/rkusa/protoc-bundled.git", rev = "3.21.6" }
 
 [dev-dependencies]

--- a/tts/Cargo.toml
+++ b/tts/Cargo.toml
@@ -13,6 +13,7 @@ bytes.workspace = true
 log.workspace = true
 ogg = "0.9"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "json"] }
+rubato = "0.14"
 rusoto_core = { version="0.48", default_features = false, features = ["rustls"] }
 rusoto_credential = "0.48"
 rusoto_polly = { version="0.48", default_features = false, features = ["rustls"] }

--- a/tts/Cargo.toml
+++ b/tts/Cargo.toml
@@ -22,7 +22,7 @@ thiserror.workspace = true
 tokio.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies.windows]
-version = "0.40"
+version = "0.48"
 features = [
   "Foundation",
   "Foundation_Collections",

--- a/tts/src/aws.rs
+++ b/tts/src/aws.rs
@@ -33,7 +33,7 @@ pub async fn synthesize(text: &str, config: &AwsConfig) -> Result<Vec<Vec<u8>>, 
     let response = client.synthesize_speech(req).await?;
 
     let wav = response.audio_stream.ok_or(AwsError::MissingAudioStream)?;
-    Ok(crate::wav_to_opus(wav).await?)
+    Ok(crate::wav_to_opus(wav, 16_000).await?)
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -43,7 +43,7 @@ pub enum AwsError {
     #[error("AWS Polly response did not contain an audio stream")]
     MissingAudioStream,
     #[error("failed to encode audio data as opus")]
-    Opus(#[from] audiopus::Error),
+    Encode(#[from] crate::WaveToOpsError),
     #[error("failed to synthesize text to speech")]
     Synthesize(#[from] rusoto_core::RusotoError<rusoto_polly::SynthesizeSpeechError>),
 }

--- a/tts/src/coqui.rs
+++ b/tts/src/coqui.rs
@@ -1,0 +1,37 @@
+use std::str::FromStr;
+
+use reqwest::Url;
+
+#[derive(Debug)]
+pub struct CoquiConfig {
+    pub addr: Option<String>,
+    pub voice: Option<String>,
+}
+
+/// Synthesize the `text` using Coqui (server). Returns a vec of opus frames.
+pub async fn synthesize(text: &str, config: &CoquiConfig) -> Result<Vec<Vec<u8>>, CoquiError> {
+    let url = config.addr.as_deref().unwrap_or("http://localhost:4000");
+    let mut url = Url::from_str(url).map_err(|_| CoquiError::InvalidAddr(url.to_string()))?;
+    url.set_path("api/tts");
+    url.query_pairs_mut()
+        .append_pair("speaker_id", config.voice.as_deref().unwrap_or("p250"))
+        .append_pair("text", text);
+
+    let res = reqwest::get(url).await?.error_for_status()?;
+    let wav = res.bytes().await?;
+    Ok(crate::wav_to_opus(wav, 22_050).await?)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CoquiError {
+    #[error(transparent)]
+    Request(#[from] reqwest::Error),
+    #[error("error reading ogg packet")]
+    Ogg(#[from] ogg::OggReadError),
+    #[error("failed to base64 decode audio data")]
+    Base64(#[from] base64::DecodeError),
+    #[error("invalid coqui address: {0}")]
+    InvalidAddr(String),
+    #[error("failed to encode audio data as opus")]
+    Encode(#[from] crate::WaveToOpsError),
+}

--- a/tts/src/lib.rs
+++ b/tts/src/lib.rs
@@ -2,12 +2,17 @@ use std::error;
 
 pub use aws::{AwsConfig, Region as AwsRegion};
 pub use azure::AzureConfig;
+pub use coqui::CoquiConfig;
 pub use gcloud::GCloudConfig;
+use rubato::{
+    Resampler, SincFixedIn, SincInterpolationParameters, SincInterpolationType, WindowFunction,
+};
 #[cfg(target_os = "windows")]
 pub use win::WinConfig;
 
 mod aws;
 mod azure;
+mod coqui;
 mod gcloud;
 #[cfg(target_os = "windows")]
 mod win;
@@ -16,6 +21,7 @@ mod win;
 pub enum TtsConfig {
     Aws(aws::AwsConfig),
     Azure(azure::AzureConfig),
+    Coqui(coqui::CoquiConfig),
     GCloud(gcloud::GCloudConfig),
     #[cfg(target_os = "windows")]
     Win(win::WinConfig),
@@ -29,21 +35,50 @@ pub async fn synthesize(
     Ok(match config {
         TtsConfig::Aws(config) => aws::synthesize(text, config).await?,
         TtsConfig::Azure(config) => azure::synthesize(text, config).await?,
+        TtsConfig::Coqui(config) => coqui::synthesize(text, config).await?,
         TtsConfig::GCloud(config) => gcloud::synthesize(text, config).await?,
         #[cfg(target_os = "windows")]
         TtsConfig::Win(config) => win::synthesize(text, config).await?,
     })
 }
 
-async fn wav_to_opus(wav: bytes::Bytes) -> Result<Vec<Vec<u8>>, audiopus::Error> {
+async fn wav_to_opus(
+    wav: bytes::Bytes,
+    in_sample_rate: u32,
+) -> Result<Vec<Vec<u8>>, WaveToOpsError> {
     use audiopus::coder::Encoder;
     use audiopus::{Application, Channels, SampleRate};
 
     tokio::task::spawn_blocking(move || {
-        let audio_stream = wav
+        const PCM_MAX: i16 = 0x7FFF;
+        const PCM_DIV: f32 = 1.0 / PCM_MAX as f32;
+        let mut audio_stream = wav
             .chunks(2)
-            .map(|bytes| i16::from_le_bytes(bytes.try_into().unwrap()))
+            .map(|bytes| PCM_DIV * i16::from_le_bytes(bytes.try_into().unwrap()) as f32)
             .collect::<Vec<_>>();
+
+        if in_sample_rate != 16_000 {
+            let params = SincInterpolationParameters {
+                sinc_len: 256,
+                f_cutoff: 0.95,
+                interpolation: SincInterpolationType::Linear,
+                oversampling_factor: 256,
+                window: WindowFunction::BlackmanHarris2,
+            };
+            audio_stream = SincFixedIn::<f32>::new(
+                16_000.0 / in_sample_rate as f64,
+                2.0,
+                params,
+                audio_stream.len(),
+                1,
+            )?
+            .process(&[&audio_stream], None)?
+            .into_iter()
+            .next()
+            .unwrap()
+        }
+
+        log::error!("ASDF {}", audio_stream.len());
 
         const MONO_20MS: usize = 16000 /* 1 channel */ * 20 / 1000;
         let enc = Encoder::new(SampleRate::Hz16000, Channels::Mono, Application::Voip)?;
@@ -52,14 +87,24 @@ async fn wav_to_opus(wav: bytes::Bytes) -> Result<Vec<Vec<u8>>, audiopus::Error>
         let mut frames = Vec::new();
 
         while pos + MONO_20MS < audio_stream.len() {
-            let len = enc.encode(&audio_stream[pos..(pos + MONO_20MS)], &mut output)?;
+            let len = enc.encode_float(&audio_stream[pos..(pos + MONO_20MS)], &mut output)?;
             frames.push(output[..len].to_vec());
 
             pos += MONO_20MS;
         }
 
-        Ok::<_, audiopus::Error>(frames)
+        Ok::<_, WaveToOpsError>(frames)
     })
     .await
     .unwrap()
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum WaveToOpsError {
+    #[error(transparent)]
+    Opus(#[from] audiopus::Error),
+    #[error(transparent)]
+    Sample(#[from] rubato::ResamplerConstructionError),
+    #[error(transparent)]
+    Resample(#[from] rubato::ResampleError),
 }

--- a/tts/src/win.rs
+++ b/tts/src/win.rs
@@ -99,7 +99,7 @@ pub async fn synthesize(text: &str, config: &WinConfig) -> Result<Vec<Vec<u8>>, 
 
     drop(lock);
 
-    Ok(crate::wav_to_opus(wav.into()).await?)
+    Ok(crate::wav_to_opus(wav.into(), 16_000).await?)
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -109,7 +109,7 @@ pub enum WinError {
     #[error("Runtime error")]
     Io(#[from] std::io::Error),
     #[error("failed to encode audio data as opus")]
-    Opus(#[from] audiopus::Error),
+    Encode(#[from] crate::WaveToOpsError),
 }
 
 impl From<windows::core::Error> for WinError {


### PR DESCRIPTION
Added [Coqui](https://github.com/coqui-ai/TTS) as another TTS provider (that can be run locally).

It is bummer, that it can not be directly integrated ('cause it's Python based), but offers way better quality than the Windows TTS. See README for instructions.

Sample:
[tts.zip](https://github.com/DCS-gRPC/rust-server/files/11929543/tts.zip)

Should we go ahead and at it even though it requires to run Coqui as a separate server? @rurounijones what do you think?

Alternatives:
https://github.com/rhasspy/piper is the only TTS I know that could be directly integrated into DCS-gRPC eventually (once it builds on Windows and the build steps allow a reasonable integration into `cargo build`).

