### PR TITLE
Feature/get draw argument value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `DestroyUnit` API
 - Added `GetClients` to `SrsService`, which retrieves a list of units that are connected to SRS and the frequencies they are connected to.
 - Added `SrsConnectEvent` and `SrsDisconnectEvent` events 
+- Added `GetDrawArgumentValue` API for units, which returns the value for drawing. (useful for "hook down", "doors open" checks)
 
 ### Fixed
 - Fixed `MarkAddEvent`, `MarkChangeEvent` and `MarkRemoveEvent` position

--- a/STATUS.md
+++ b/STATUS.md
@@ -380,7 +380,7 @@ Primarily enhanced with `GRPC.exporters.unit`
   - [ ] `getSensors`
   - [ ] `hasSensors`
   - [ ] `getRadar`
-  - [ ] `getDrawArgumentValue`
+  - [x] `getDrawArgumentValue`
   - [ ] `getNearestCargos`
   - [ ] `enableEmission`
   - [ ] `getDescentCateogry`

--- a/lua/DCS-gRPC/methods/unit.lua
+++ b/lua/DCS-gRPC/methods/unit.lua
@@ -46,6 +46,18 @@ GRPC.methods.getRadar = function(params)
   })
 end
 
+GRPC.methods.getDrawArgumentValue = function (params)
+  -- https://wiki.hoggitworld.com/view/DCS_func_getDrawArgumentValue
+  local unit = Unit.getByName(params.name)
+  if unit == nil then
+    return GRPC.errorNotFound("unit does not exist")
+  end
+
+  return GRPC.success({
+    value = unit:getDrawArgumentValue(params.argument)
+  })
+end
+
 GRPC.methods.getUnitPosition = function(params)
   -- https://wiki.hoggitworld.com/view/DCS_func_getByName
   local unit = Unit.getByName(params.name)

--- a/protos/dcs/unit/v0/unit.proto
+++ b/protos/dcs/unit/v0/unit.proto
@@ -31,6 +31,9 @@ service UnitService {
 
   // https://wiki.hoggitworld.com/view/DCS_func_destroy
   rpc Destroy(DestroyRequest) returns (DestroyResponse) {}
+
+  // https://wiki.hoggitworld.com/view/DCS_func_getDrawArgumentValue
+  rpc GetDrawArgumentValue(GetDrawArgumentValueRequest) returns (GetDrawArgumentValueResponse) {}
 }
 
 message GetRadarRequest {

--- a/protos/dcs/unit/v0/unit.proto
+++ b/protos/dcs/unit/v0/unit.proto
@@ -50,6 +50,15 @@ message GetPositionResponse {
   dcs.common.v0.Position position = 1;
 }
 
+message GetDrawArgumentValueRequest {
+  string name = 1;
+  uint32 argument = 2;
+}
+
+message GetDrawArgumentValueResponse {
+  double value = 1;
+}
+
 message GetTransformRequest {
   string name = 1;
 }

--- a/src/rpc/unit.rs
+++ b/src/rpc/unit.rs
@@ -49,7 +49,7 @@ impl UnitService for MissionRpc {
     async fn get_draw_argument_value(
         &self,
         request: Request<unit::v0::GetDrawArgumentValueRequest>,
-    ) -> Result<Response<unit::v0::GetDrawArgumentValueResponse>, Status>{
+    ) -> Result<Response<unit::v0::GetDrawArgumentValueResponse>, Status> {
         let res = self.request("getDrawArgumentValue", request).await?;
         Ok(Response::new(res))
     }

--- a/src/rpc/unit.rs
+++ b/src/rpc/unit.rs
@@ -46,6 +46,14 @@ impl UnitService for MissionRpc {
         Ok(Response::new(res))
     }
 
+    async fn get_draw_argument_value(
+        &self,
+        request: Request<unit::v0::GetDrawArgumentValueRequest>,
+    ) -> Result<Response<unit::v0::GetDrawArgumentValueResponse>, Status>{
+        let res = self.request("getDrawArgumentValue", request).await?;
+        Ok(Response::new(res))
+    }
+
     async fn get(
         &self,
         request: Request<unit::v0::GetRequest>,


### PR DESCRIPTION
Added `unit:getDrawArgumentValue(name)` to the rust-server. 

This is handy for checking things on units like: 
- doors open/close
- flaps
- hook for carrier aircraft
and more

Tested with F-14 on the deck with hook down (cannot go down 100% due to it touching the ground): 
![image](https://github.com/user-attachments/assets/de4ef951-0664-4889-a4d6-34244904326c)

