### PR TITLE
Don't return from `onPlayerTrySendChat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the config value for `tts.defaultProvider` for Google Cloud to be lowercase `gcloud` (instead of `gCloud`)
 - Fixed error with getCategory due to API changes in DCS ([#246](https://github.com/DCS-gRPC/rust-server/issues/246))
 - Fixed export of airbase objects by filtering out ships that are no longer part of a group due to damage
+- Fixed `onPlayerTrySendChat``returning a value and therefore stopping other scripts from reacting to the event
 
 ## [0.7.1] - 2023-01-08
 

--- a/lua/DCS-gRPC/grpc-hook.lua
+++ b/lua/DCS-gRPC/grpc-hook.lua
@@ -42,6 +42,9 @@ function handler.onSimulationStop()
   grpc = nil
 end
 
+-- None of these methods should return anything as doing so breaks other scripts attempting to
+-- react to the hook as well.
+
 function handler.onPlayerTrySendChat(playerID, msg)
   -- note: currently `all` (third parameter) will always `=true` regardless if the target is to the coalition/team
   --        or to everybody. When ED fixes this, implementation should determine the dcs.common.v0.Coalition
@@ -55,7 +58,6 @@ function handler.onPlayerTrySendChat(playerID, msg)
     },
   })
 
-  return msg
 end
 
 function handler.onPlayerTryConnect(addr, name, ucid, id)
@@ -69,7 +71,6 @@ function handler.onPlayerTryConnect(addr, name, ucid, id)
       id = id,
     },
   })
-  -- not returning `true` here to allow other scripts to handle this hook
 end
 
 function handler.onPlayerDisconnect(id, reason)


### PR DESCRIPTION
Don't return a value from `onPlayerTrySendChat` as this stops other hook functions from getting their shot at reacting to the event.