### PR TITLE
Add API Key Authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `GetClients` to `SrsService`, which retrieves a list of units that are connected to SRS and the frequencies they are connected to.
 - Added `SrsConnectEvent` and `SrsDisconnectEvent` events 
 - Added `GetDrawArgumentValue` API for units, which returns the value for drawing. (useful for "hook down", "doors open" checks)
+- Added Authentication Interceptor. This enables authentication on a per client basis.
 
 ### Fixed
 - Fixed `MarkAddEvent`, `MarkChangeEvent` and `MarkRemoveEvent` position

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,6 +440,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
+ "tonic-middleware",
  "walkdir",
 ]
 
@@ -918,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -958,7 +959,7 @@ checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-util",
  "rustls 0.22.4",
  "rustls-pki-types",
@@ -981,16 +982,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.3"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1639,7 +1640,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-rustls 0.26.0",
  "hyper-util",
  "ipnet",
@@ -2359,6 +2360,18 @@ dependencies = [
  "prost-build",
  "quote",
  "syn 2.0.66",
+]
+
+[[package]]
+name = "tonic-middleware"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d34dab0f18194ddb9164685a3d8cf777ff35042752aba2be208b1384d7a304"
+dependencies = [
+ "async-trait",
+ "futures-util",
+ "tonic",
+ "tower",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ time = { version = "0.3", features = ["formatting", "parsing"] }
 tokio.workspace = true
 tokio-stream.workspace = true
 tonic.workspace = true
+tonic-middleware = "0.1.4"
 
 [build-dependencies]
 walkdir = "2.3"

--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ throughputLimit = 600
 -- Whether the integrity check, meant to spot installation issues, is disabled.
 integrityCheckDisabled = false
 
+-- Whether or not authentication is required
+auth.enabled = false 
+-- Authentication tokens table with client names and their tokens for split tokens. 
+auth.tokens = {
+  -- client => clientName, token => Any token. Advice to use UTF-8 only. Length not limited explicitly 
+  { client = "SomeClient", token = "SomeToken" }, 
+  { client = "SomeClient2", token = "SomeOtherToken" }
+}
+
 -- The default TTS provider to use if a TTS request does not explicitly specify another one.
 tts.defaultProvider = "win"
 

--- a/README.md
+++ b/README.md
@@ -226,9 +226,9 @@ In order to develop clients for `DCS-gRPC` you must be familiar with gRPC concep
 
 The gRPC .proto files are available in the `Docs/DCS-gRPC` folder and also available in the Github repo
 
-### Authentication
+### Client Authentication
 
-If authentication is enabled you will have to add `X-API-Key` to the metadata/headers. 
+If authentication is enabled on the server you will have to add `X-API-Key` to the metadata/headers. 
 Below are some example on what it could look like in your code.
 
 #### Examples

--- a/README.md
+++ b/README.md
@@ -226,6 +226,52 @@ In order to develop clients for `DCS-gRPC` you must be familiar with gRPC concep
 
 The gRPC .proto files are available in the `Docs/DCS-gRPC` folder and also available in the Github repo
 
+### Authentication
+
+If authentication is enabled you will have to add `X-API-Key` to the metadata/headers. 
+Below are some example on what it could look like in your code.
+
+#### Examples
+
+<details>
+  <summary>dotnet / c# </summary>
+
+You can either set the `Metadata` for each request or you can create a `GrpcChannel` with an interceptor that will set the key each time.
+
+For a single request: 
+
+```c#
+var client = new MissionService.MissionServiceClient(channel);
+
+Metadata metadata = new Metadata()
+{
+    { "X-API-Key", "<yourKey>" }
+};
+
+var response = client.GetScenarioCurrentTime(new GetScenarioCurrentTimeRequest { }, headers: metadata, deadline: DateTime.UtcNow.AddSeconds(2));
+```
+
+For all requests on a channel: 
+```c#
+public GrpcChannel CreateChannel(string host, string post, string? apiKey)
+{
+  GrpcChannelOptions options = new GrpcChannelOptions();
+  if (apiKey != null)
+  {
+      CallCredentials credentials = CallCredentials.FromInterceptor(async (context, metadata) =>
+      {
+          metadata.Add("X-API-Key", apiKey);
+      });
+
+      options.Credentials = ChannelCredentials.Create(ChannelCredentials.Insecure, credentials) ;
+  }
+
+  return GrpcChannel.ForAddress($"http://{host}:{port}", options);
+}
+```
+
+</details>
+
 ## Server Development
 
 The following section is only applicable to people who want to developer the DCS-gRPC server itself.

--- a/lua/DCS-gRPC/grpc-mission.lua
+++ b/lua/DCS-gRPC/grpc-mission.lua
@@ -3,6 +3,7 @@ if not GRPC then
     -- scaffold nested tables to allow direct assignment in config file
     tts = { provider = { gcloud = {}, aws = {}, azure = {}, win = {} } },
     srs = {},
+    auth = {}
   }
 end
 

--- a/lua/DCS-gRPC/grpc.lua
+++ b/lua/DCS-gRPC/grpc.lua
@@ -8,32 +8,6 @@ end
 -- load and start RPC
 --
 
-function table_print(tt, indent, done)
-  done = done or {}
-  indent = indent or 0
-  if type(tt) == "table" then
-      local sb = {}
-      for key, value in pairs(tt) do
-          table.insert(sb, string.rep(" ", indent)) -- indent it
-          if type(value) == "table" and not done[value] then
-              done[value] = true
-              table.insert(sb, key .. " = {\n");
-              table.insert(sb, table_print(value, indent + 2, done))
-              table.insert(sb, string.rep(" ", indent)) -- indent it
-              table.insert(sb, "}\n");
-          elseif "number" == type(key) then
-              table.insert(sb, string.format("\"%s\"\n", tostring(value)))
-          else
-              table.insert(sb, string.format(
-                  "%s = \"%s\"\n", tostring(key), tostring(value)))
-          end
-      end
-      return table.concat(sb)
-  else
-      return tt .. "\n"
-  end
-end
-
 if isMissionEnv then
   assert(grpc.start({
     version = GRPC.version,

--- a/lua/DCS-gRPC/grpc.lua
+++ b/lua/DCS-gRPC/grpc.lua
@@ -8,6 +8,32 @@ end
 -- load and start RPC
 --
 
+function table_print(tt, indent, done)
+  done = done or {}
+  indent = indent or 0
+  if type(tt) == "table" then
+      local sb = {}
+      for key, value in pairs(tt) do
+          table.insert(sb, string.rep(" ", indent)) -- indent it
+          if type(value) == "table" and not done[value] then
+              done[value] = true
+              table.insert(sb, key .. " = {\n");
+              table.insert(sb, table_print(value, indent + 2, done))
+              table.insert(sb, string.rep(" ", indent)) -- indent it
+              table.insert(sb, "}\n");
+          elseif "number" == type(key) then
+              table.insert(sb, string.format("\"%s\"\n", tostring(value)))
+          else
+              table.insert(sb, string.format(
+                  "%s = \"%s\"\n", tostring(key), tostring(value)))
+          end
+      end
+      return table.concat(sb)
+  else
+      return tt .. "\n"
+  end
+end
+
 if isMissionEnv then
   assert(grpc.start({
     version = GRPC.version,
@@ -21,6 +47,7 @@ if isMissionEnv then
     integrityCheckDisabled = GRPC.integrityCheckDisabled,
     tts = GRPC.tts,
     srs = GRPC.srs,
+    auth = GRPC.auth
   }))
 end
 

--- a/lua/Hooks/DCS-gRPC.lua
+++ b/lua/Hooks/DCS-gRPC.lua
@@ -9,6 +9,7 @@ local function init()
       -- scaffold nested tables to allow direct assignment in config file
       tts = { provider = { gcloud = {}, aws = {}, azure = {}, win = {} } },
       srs = {},
+      auth = {}
     }
   end
 

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -12,16 +12,29 @@ pub struct AuthInterceptor {
 #[async_trait]
 impl RequestInterceptor for AuthInterceptor {
     async fn intercept(&self, req: Request<Body>) -> Result<Request<Body>, Status> {
-        match req.headers().get("X-API-Key").map(|v| v.to_str()) {
-            Some(Ok(token)) => {
-                //check if token is correct if auth is enabled
-                if self.auth_config.enabled == false || token == self.auth_config.token {
-                    Ok(req)
-                } else {
-                    Err(Status::unauthenticated("Unauthenticated"))
+        if !self.auth_config.enabled {
+            Ok(req)
+        } else {
+            match req.headers().get("X-API-Key").map(|v| v.to_str()) {
+                Some(Ok(token)) => {
+                    //check if token is correct if auth is 
+                    let mut client: Option<&String> = None;
+                    for key in &self.auth_config.tokens {
+                        if key.token == token {
+                            client = Some(&key.client);
+                            break;
+                        }
+                    }
+
+                    if client.is_some() {
+                        log::debug!("Authenticated client: {}", client.unwrap());
+                        Ok(req)
+                    } else {
+                        Err(Status::unauthenticated("Unauthenticated"))
+                    }
                 }
+                _ => Err(Status::unauthenticated("Unauthenticated")),
             }
-            _ => Err(Status::unauthenticated("Unauthenticated")),
         }
     }
 }

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -12,7 +12,7 @@ pub struct AuthInterceptor {
 #[async_trait]
 impl RequestInterceptor for AuthInterceptor {
     async fn intercept(&self, req: Request<Body>) -> Result<Request<Body>, Status> {
-        match req.headers().get("bearer").map(|v| v.to_str()) {
+        match req.headers().get("X-API-Key").map(|v| v.to_str()) {
             Some(Ok(token)) => {
                 //check if token is correct if auth is enabled
                 if self.auth_config.enabled == false || token == self.auth_config.token {

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -1,0 +1,27 @@
+use crate::config::AuthConfig;
+use tonic::codegen::http::Request;
+use tonic::transport::Body;
+use tonic::{async_trait, Status};
+use tonic_middleware::RequestInterceptor;
+
+#[derive(Clone)]
+pub struct AuthInterceptor {
+    pub auth_config: AuthConfig,
+}
+
+#[async_trait]
+impl RequestInterceptor for AuthInterceptor {
+    async fn intercept(&self, req: Request<Body>) -> Result<Request<Body>, Status> {
+        match req.headers().get("bearer").map(|v| v.to_str()) {
+            Some(Ok(token)) => {
+                //check if token is correct if auth is enabled
+                if self.auth_config.enabled == false || token == self.auth_config.token {
+                    Ok(req)
+                } else {
+                    Err(Status::unauthenticated("Unauthenticated"))
+                }
+            }
+            _ => Err(Status::unauthenticated("Unauthenticated")),
+        }
+    }
+}

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -17,7 +17,6 @@ impl RequestInterceptor for AuthInterceptor {
         } else {
             match req.headers().get("X-API-Key").map(|v| v.to_str()) {
                 Some(Ok(token)) => {
-                    //check if token is correct if auth is 
                     let mut client: Option<&String> = None;
                     for key in &self.auth_config.tokens {
                         if key.token == token {

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,6 +93,14 @@ pub struct SrsConfig {
 pub struct AuthConfig {
     #[serde(default)]
     pub enabled: bool,
+    pub tokens: Vec<ApiKey>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiKey {
+    #[serde(default)]
+    pub client: String,
     pub token: String,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,7 @@ pub struct Config {
     pub integrity_check_disabled: bool,
     pub tts: Option<TtsConfig>,
     pub srs: Option<SrsConfig>,
+    pub auth: Option<AuthConfig>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -85,6 +86,14 @@ pub struct WinConfig {
 pub struct SrsConfig {
     #[serde(default)]
     pub addr: Option<SocketAddr>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    pub token: String,
 }
 
 fn default_host() -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 #![recursion_limit = "256"]
 
+mod authentication;
 mod config;
 mod fps;
 #[cfg(feature = "hot-reload")]


### PR DESCRIPTION
Added API Key authentication. 

Due to a recurring question about authentication of clients I've implemented a Interceptor layer to the tonic server to check all calls for valid api keys. 

example config: 
```
auth.enabled = false --defaults to false
auth.tokens = {
    { client = "test", token = "Sometest" },
    { client = "another client", token = "Some other test" }
}
```
`auth.tokens` is a table of auth keys with their client name. 
There can be a "default" client or a single key for all clients, but this is up to configuration. 
There can be as many client keys as needed. 

In the debug log the client that authenticates is logged. 

### Performance
Performance wise there is no notable difference. 

### Possible future features
Possibly in the future "expiration_date" can be added to automatically revoke issues, but I didn't think that was needed for a first implementation. 

