### PR TITLE
Fixed Auth token issues

### DIFF
--- a/lua/DCS-gRPC/grpc-mission.lua
+++ b/lua/DCS-gRPC/grpc-mission.lua
@@ -3,7 +3,7 @@ if not GRPC then
     -- scaffold nested tables to allow direct assignment in config file
     tts = { provider = { gcloud = {}, aws = {}, azure = {}, win = {} } },
     srs = {},
-    auth = {}
+    auth = { tokens = {} }
   }
 end
 

--- a/lua/Hooks/DCS-gRPC.lua
+++ b/lua/Hooks/DCS-gRPC.lua
@@ -9,7 +9,7 @@ local function init()
       -- scaffold nested tables to allow direct assignment in config file
       tts = { provider = { gcloud = {}, aws = {}, azure = {}, win = {} } },
       srs = {},
-      auth = {}
+      auth = { tokens = {} }
     }
   end
 


### PR DESCRIPTION
Due to a oversight on my part a default value for the value `tokens` in `auth` was not added. 
This causes grpc to not start up at all due to null reference. 

This fixes it and set a default empty object just like for tts.  