### PR TITLE
Added RunwayTouch and RunwayTakeoff for more accurate TakeOff and Lan…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Events `OnRunwayTouch` and `RunwayTakeoff` for "changed" TakeOff and Landing logic in DCS.
+
 ## [0.8.0]
 
 ### Breaking Changes

--- a/STATUS.md
+++ b/STATUS.md
@@ -203,6 +203,8 @@ should use their independent logging and tracing functions.
 - [x] `S_EVENT_HIT`
 - [x] `S_EVENT_TAKEOFF`
 - [x] `S_EVENT_LAND`
+- [x] `S_EVENT_RUNWAY_TAKEOFF`
+- [x] `S_EVENT_RUNWAY_TOUCH`
 - [x] `S_EVENT_CRASH`
 - [x] `S_EVENT_EJECTION`
 - [x] `S_EVENT_REFUELING`

--- a/lua/DCS-gRPC/methods/mission.lua
+++ b/lua/DCS-gRPC/methods/mission.lua
@@ -96,11 +96,31 @@ GRPC.onDcsEvent = function(event)
       },
     }
 
+  elseif event.id == world.event.S_EVENT_RUNWAY_TAKEOFF then
+    return {
+      time = event.time,
+      event = {
+        type = "runwayTakeoff",
+        initiator = {initiator = typed_exporter(event.initiator)},
+        place = exporter(event.place),
+      },
+    }
+
   elseif event.id == world.event.S_EVENT_LAND then
     return {
       time = event.time,
       event = {
         type = "land",
+        initiator = {initiator = typed_exporter(event.initiator)},
+        place = exporter(event.place),
+      },
+    }
+
+  elseif event.id == world.event.S_EVENT_RUNWAY_TOUCH then
+    return {
+      time = event.time,
+      event = {
+        type = "runwayTouch",
         initiator = {initiator = typed_exporter(event.initiator)},
         place = exporter(event.place),
       },

--- a/protos/dcs/mission/v0/mission.proto
+++ b/protos/dcs/mission/v0/mission.proto
@@ -119,8 +119,24 @@ message StreamEventsResponse {
     dcs.common.v0.Airbase place = 2;
   }
 
+  // Occurs when an aircraft takes off from an airbase, farp, or ship.
+  message RunwayTakeoffEvent {
+    // The object that took off.
+    dcs.common.v0.Initiator initiator = 1;
+    // The airbase, farp or ship the unit took off from.
+    dcs.common.v0.Airbase place = 2;
+  }
+
   // Occurs when an aircraft lands at an airbase, farp or ship.
   message LandEvent {
+    // The object that landed.
+    dcs.common.v0.Initiator initiator = 1;
+    // The airbase, farp or ship the unit landed at.
+    dcs.common.v0.Airbase place = 2;
+  }
+
+  // Occurs when an aircraft lands at an airbase, farp or ship.
+  message RunwayTouchEvent {
     // The object that landed.
     dcs.common.v0.Initiator initiator = 1;
     // The airbase, farp or ship the unit landed at.
@@ -538,6 +554,9 @@ message StreamEventsResponse {
     // @exclude 38 reserved for S_EVENT_TRIGGER_ZONE
     LandingQualityMarkEvent landing_quality_mark = 39;
     // @exclude 40 reserved for S_EVENT_BDA
+
+    RunwayTakeoffEvent runway_takeoff = 54;
+    RunwayTouchEvent runway_touch = 55;
 
     // The following events are additions on top of DCS's own event enum,
     // which is why they start at 8192 to give DCS plenty of space for


### PR DESCRIPTION
As referenced in the below image. 
DCS Changed the Land and Touchdown events' behaviour and implemented the original behaviour (exact touch/no touch) in new events. 

These new events are `RunwayTouch` and RunwayTakeoff` which are now added with this release.
Apparently 2.9.6 changed it.

https://wiki.hoggitworld.com/view/DCS_event_takeoff

![image](https://github.com/user-attachments/assets/594e4128-5b52-44c6-a6dd-51e40928de4d)

To summize the new behaviour since 2.9.6: 

- `S_EVENT_LAND` : Occurs when an aircraft lands at an airbase, farp or ship and sufficiently slows down. 
- `S_EVENT_TAKEOFF`: Occurs when an aircraft takes off from an airbase, farp, or ship. Occurs several seconds after take-off. 
- `S_EVENT_RUNWAY_TOUCH`: Occurs the moment when the player aircraft aircraft lands at an airbase, farp or ship. 
- `S_EVENT_RUNWAY_TAKEOFF`: Occurs when an aircraft leaves the ground and takes off. 


Previously the `S_EVENT_LAND` and `S_EVENT_TAKEOFF` would trigger instantly, but they only fire now when DCS logically assumes a successful takeoff/landing was performed.
`S_EVENT_RUNWAY_TOUCH` and `S_EVENT_RUNWAY_TAKEOFF` were (assumingly) added to still expose the earlier behaviour.
 
