### PR TITLE
Add world.searchObjects RPC with volume support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- World: `SearchObjects` RPC mirroring `world.searchObjects` with full volume support (sphere, box, segment, pyramid).
+  - Request uses `dcs.common.v0.ObjectCategory[]` and `SearchVolume` (with `InputPosition` for geo points).
+  - Response returns `dcs.common.v0.Target[]` for consistent object union across services.
+  - Lua implementation unwraps grpcui oneof wrapper (`volume.shape`) and supports both wrapped and flattened shapes.
+
 ## [0.8.1] 2024-11-05
 
 ### Added

--- a/lua/DCS-gRPC/methods/world.lua
+++ b/lua/DCS-gRPC/methods/world.lua
@@ -2,9 +2,11 @@
 -- RPC world actions
 -- https://wiki.hoggitworld.com/view/DCS_singleton_world
 --
+-- luacheck: globals world coalition Object env coord
 
 local world = world
 local coalition = coalition
+local Object = Object
 local GRPC = GRPC
 
 GRPC.methods.getAirbases = function(params)
@@ -53,4 +55,174 @@ end
 
 GRPC.methods.getTheatre = function()
   return GRPC.success({theatre = env.mission.theatre})
+end
+
+-- https://wiki.hoggitworld.com/view/DCS_func_searchObjects
+GRPC.methods.searchObjects = function(params)
+  GRPC.logInfo("searchObjects: invoked")
+  if params.categories == nil or #params.categories == 0 then
+    return GRPC.errorInvalidArgument("categories must not be empty")
+  end
+
+  if params.volume == nil then
+    return GRPC.errorInvalidArgument("volume is required")
+  end
+
+  local v = params.volume
+  local volume
+
+  -- Debug: log incoming volume keys
+  do
+    local keys = {}
+    for k, _ in pairs(v or {}) do keys[#keys+1] = tostring(k) end
+    GRPC.logInfo("searchObjects: volume keys="..table.concat(keys, ","))
+  end
+
+  -- If grpcui/serde wrapped oneof under a `shape` table, unwrap it
+  if v and v.shape and type(v.shape) == "table" then
+    v = v.shape
+    local keys = {}
+    for k, _ in pairs(v or {}) do keys[#keys+1] = tostring(k) end
+    GRPC.logInfo("searchObjects: unwrapped shape; inner keys="..table.concat(keys, ","))
+  end
+
+  -- If grpcui sent a discriminator value, prefer it
+  local discriminator = nil
+  if params.volume and params.volume.shape and type(params.volume.shape) ~= "table" then
+    if type(params.volume.shape) == "string" then
+      discriminator = string.lower(params.volume.shape)
+    elseif type(params.volume.shape) == "number" then
+      -- Best-effort mapping (fallback only)
+      local map = { [1] = "sphere", [2] = "box", [3] = "segment", [4] = "pyramid" }
+      discriminator = map[params.volume.shape]
+    end
+    GRPC.logInfo("searchObjects: discriminator="..tostring(discriminator))
+  end
+
+  -- Detect sphere
+  if (discriminator == "sphere") or v.sphere ~= nil or (v.center ~= nil and v.radius ~= nil and v.min == nil and v.from == nil and v.forward == nil) then
+    local s = v.sphere or v
+    local center = s.center
+    local radius = s.radius
+    if center == nil or radius == nil then
+      return GRPC.errorInvalidArgument("sphere center and radius are required")
+    end
+    local lo = coord.LLtoLO(center.lat, center.lon)
+    GRPC.logInfo("searchObjects: volume SPHERE radius="..tostring(radius))
+    volume = {
+      id = world.VolumeType.SPHERE,
+      params = {
+        point = { x = lo.x, y = center.alt or 0, z = lo.z },
+        radius = radius,
+      }
+    }
+  -- Detect box
+  elseif (discriminator == "box") or v.box ~= nil or (v.min ~= nil and v.max ~= nil) then
+    local b = v.box or v
+    local min = b.min
+    local max = b.max
+    if min == nil or max == nil then
+      return GRPC.errorInvalidArgument("box min and max are required")
+    end
+    local minLo = coord.LLtoLO(min.lat, min.lon)
+    local maxLo = coord.LLtoLO(max.lat, max.lon)
+    GRPC.logInfo("searchObjects: volume BOX")
+    volume = {
+      id = world.VolumeType.BOX,
+      params = {
+        min = { x = minLo.x, y = min.alt or 0, z = minLo.z },
+        max = { x = maxLo.x, y = max.alt or 0, z = maxLo.z },
+      }
+    }
+  -- Detect segment
+  elseif (discriminator == "segment") or v.segment ~= nil or (v.from ~= nil and v.to ~= nil) then
+    local seg = v.segment or v
+    local from = seg.from
+    local to = seg.to
+    if from == nil or to == nil then
+      return GRPC.errorInvalidArgument("segment from and to are required")
+    end
+    local fromLo = coord.LLtoLO(from.lat, from.lon)
+    local toLo = coord.LLtoLO(to.lat, to.lon)
+    GRPC.logInfo("searchObjects: volume SEGMENT")
+    volume = {
+      id = world.VolumeType.SEGMENT,
+      params = {
+        from = { x = fromLo.x, y = from.alt or 0, z = fromLo.z },
+        to = { x = toLo.x, y = to.alt or 0, z = toLo.z },
+      }
+    }
+  -- Detect pyramid
+  elseif (discriminator == "pyramid") or v.pyramid ~= nil or (v.center ~= nil and v.forward ~= nil and v.right ~= nil and v.up ~= nil and v.length ~= nil and (v.halfAngleHorizontal ~= nil and v.halfAngleVertical ~= nil)) then
+    local pv = v.pyramid or v
+    if pv.center == nil or pv.length == nil or pv.halfAngleHorizontal == nil or pv.halfAngleVertical == nil then
+      return GRPC.errorInvalidArgument("pyramid center, length and angles are required")
+    end
+
+    local fwd = pv.forward
+    local up = pv.up
+    local right = pv.right
+
+    local function normalize(v)
+      local mag = math.sqrt((v.x or 0)^2 + (v.y or 0)^2 + (v.z or 0)^2)
+      if mag == 0 then return { x = 0, y = 1, z = 0 } end
+      return { x = v.x / mag, y = v.y / mag, z = v.z / mag }
+    end
+
+    if fwd == nil or right == nil or up == nil then
+      return GRPC.errorInvalidArgument("pyramid requires forward/right/up vectors")
+    end
+    fwd = normalize(fwd)
+    right = normalize(right)
+    up = normalize(up)
+
+    local centerLo = coord.LLtoLO(pv.center.lat, pv.center.lon)
+    GRPC.logInfo("searchObjects: volume PYRAMID length="..tostring(pv.length))
+    volume = {
+      id = world.VolumeType.PYRAMID,
+      params = {
+        pos = {
+          p = { x = centerLo.x, y = pv.center.alt or 0, z = centerLo.z },
+          x = fwd,
+          y = up,
+          z = right,
+        },
+        length = pv.length,
+        halfAngleHor = pv.halfAngleHorizontal,
+        halfAngleVer = pv.halfAngleVertical,
+      }
+    }
+  else
+    GRPC.logWarning("searchObjects: unknown volume type; expected sphere/box/segment/pyramid")
+    return GRPC.errorInvalidArgument("unknown volume type")
+  end
+
+  local result = {}
+  local function handler(object, _)
+    local cat = object:getCategory()
+    if cat == Object.Category.UNIT then
+      result[#result+1] = { target = { unit = GRPC.exporters.unit(object) } }
+    elseif cat == Object.Category.WEAPON then
+      result[#result+1] = { target = { weapon = GRPC.exporters.weapon(object) } }
+    elseif cat == Object.Category.STATIC then
+      result[#result+1] = { target = { static = GRPC.exporters.static(object) } }
+    elseif cat == Object.Category.SCENERY then
+      result[#result+1] = { target = { scenery = GRPC.exporters.scenery(object) } }
+    elseif cat == Object.Category.BASE then
+      result[#result+1] = { target = { airbase = GRPC.exporters.airbase(object) } }
+    elseif cat == Object.Category.CARGO then
+      result[#result+1] = { target = { cargo = GRPC.exporters.cargo() } }
+    else
+      result[#result+1] = { target = { unknown = GRPC.exporters.unknown(object) } }
+    end
+    return true
+  end
+
+  for _, cat in ipairs(params.categories) do
+    GRPC.logInfo("searchObjects: calling world.searchObjects for category="..tostring(cat))
+    world.searchObjects(cat, volume, handler, nil)
+  end
+
+  GRPC.logInfo("searchObjects: returning objects count="..tostring(#result))
+  return GRPC.success({objects = result})
 end

--- a/lua/DCS-gRPC/methods/world.lua
+++ b/lua/DCS-gRPC/methods/world.lua
@@ -100,7 +100,13 @@ GRPC.methods.searchObjects = function(params)
   end
 
   -- Detect sphere
-  if (discriminator == "sphere") or v.sphere ~= nil or (v.center ~= nil and v.radius ~= nil and v.min == nil and v.from == nil and v.forward == nil) then
+  if (discriminator == "sphere")
+    or v.sphere ~= nil
+    or (
+      v.center ~= nil and v.radius ~= nil and
+      v.min == nil and v.from == nil and v.forward == nil
+    )
+  then
     local s = v.sphere or v
     local center = s.center
     local radius = s.radius
@@ -153,7 +159,15 @@ GRPC.methods.searchObjects = function(params)
       }
     }
   -- Detect pyramid
-  elseif (discriminator == "pyramid") or v.pyramid ~= nil or (v.center ~= nil and v.forward ~= nil and v.right ~= nil and v.up ~= nil and v.length ~= nil and (v.halfAngleHorizontal ~= nil and v.halfAngleVertical ~= nil)) then
+  elseif (discriminator == "pyramid")
+    or v.pyramid ~= nil
+    or (
+      v.center ~= nil and v.forward ~= nil and v.right ~= nil and v.up ~= nil and
+      v.length ~= nil and (
+        v.halfAngleHorizontal ~= nil and v.halfAngleVertical ~= nil
+      )
+    )
+  then
     local pv = v.pyramid or v
     if pv.center == nil or pv.length == nil or pv.halfAngleHorizontal == nil or pv.halfAngleVertical == nil then
       return GRPC.errorInvalidArgument("pyramid center, length and angles are required")
@@ -163,10 +177,10 @@ GRPC.methods.searchObjects = function(params)
     local up = pv.up
     local right = pv.right
 
-    local function normalize(v)
-      local mag = math.sqrt((v.x or 0)^2 + (v.y or 0)^2 + (v.z or 0)^2)
+    local function normalize(vec)
+      local mag = math.sqrt((vec.x or 0)^2 + (vec.y or 0)^2 + (vec.z or 0)^2)
       if mag == 0 then return { x = 0, y = 1, z = 0 } end
-      return { x = v.x / mag, y = v.y / mag, z = v.z / mag }
+      return { x = vec.x / mag, y = vec.y / mag, z = vec.z / mag }
     end
 
     if fwd == nil or right == nil or up == nil then

--- a/protos/dcs/world/v0/world.proto
+++ b/protos/dcs/world/v0/world.proto
@@ -14,6 +14,9 @@ service WorldService {
 
   // Returns the theatre (Map name) of the mission
   rpc GetTheatre(GetTheatreRequest) returns (GetTheatreResponse) {}
+
+  // https://wiki.hoggitworld.com/view/DCS_func_searchObjects
+  rpc SearchObjects(SearchObjectsRequest) returns (SearchObjectsResponse) {}
 }
 
 message GetAirbasesRequest {
@@ -36,4 +39,66 @@ message GetTheatreRequest {
 
 message GetTheatreResponse {
   string theatre = 1;
+}
+
+/**
+ * Search objects inside a 3D volume by category.
+ *
+ */
+message SearchObjectsRequest {
+  // Object categories to search for. If empty, no objects will be returned.
+  repeated dcs.common.v0.ObjectCategory categories = 1;
+
+  // The search volume.
+  SearchVolume volume = 2;
+}
+
+message SearchObjectsResponse {
+  // Objects found inside the volume.
+  repeated dcs.common.v0.Target objects = 1;
+}
+
+// Volume used by world.searchObjects.
+message SearchVolume {
+  oneof shape {
+    SphereVolume sphere = 1;
+    BoxVolume box = 2;
+    SegmentVolume segment = 3;
+    PyramidVolume pyramid = 4;
+  }
+}
+
+message SphereVolume {
+  // Center point in geographic coordinates.
+  dcs.common.v0.InputPosition center = 1;
+  // Radius in meters.
+  double radius = 2;
+}
+
+message BoxVolume {
+  // Minimum corner in geographic coordinates.
+  dcs.common.v0.InputPosition min = 1;
+  // Maximum corner in geographic coordinates.
+  dcs.common.v0.InputPosition max = 2;
+}
+
+message SegmentVolume {
+  // Start point in geographic coordinates.
+  dcs.common.v0.InputPosition from = 1;
+  // End point in geographic coordinates.
+  dcs.common.v0.InputPosition to = 2;
+}
+
+message PyramidVolume {
+  // Center point of the pyramid vertex in geographic coordinates.
+  dcs.common.v0.InputPosition center = 1;
+  // Orientation unit vectors defining the pyramid. Should be normalized.
+  dcs.common.v0.Vector forward = 2;
+  dcs.common.v0.Vector right = 3;
+  dcs.common.v0.Vector up = 4;
+  // Max distance from vertex to objects considered inside the pyramid.
+  double length = 5;
+  // Horizontal and vertical half-angles in radians.
+  double half_angle_horizontal = 6;
+  double half_angle_vertical = 7;
 }

--- a/src/rpc/world.rs
+++ b/src/rpc/world.rs
@@ -29,4 +29,12 @@ impl WorldService for MissionRpc {
         let res = self.request("getTheatre", request).await?;
         Ok(Response::new(res))
     }
+
+    async fn search_objects(
+        &self,
+        request: Request<world::v0::SearchObjectsRequest>,
+    ) -> Result<Response<world::v0::SearchObjectsResponse>, Status> {
+        let res = self.request("searchObjects", request).await?;
+        Ok(Response::new(res))
+    }
 }


### PR DESCRIPTION
Expose DCS’ world.searchObjects via WorldService/SearchObjects with full volume support (sphere, box, segment, pyramid).

- Proto: define SearchObjectsRequest with SearchVolume (sphere/box/ segment/pyramid) using InputPosition for geo points; response returns dcs.common.v0.Target[] to reuse the existing union object type
- Lua: implement GRPC.methods.searchObjects; build DCS volume tables (world.VolumeType.*) and flattened shapes; return objects wrapped in Target oneof
- Rust: wire WorldService::search_objects to Lua method


Example request payload:

```json
{
  "categories": [1],
  "volume": {
    "sphere": {
      "center": { "lat": 41.9, "lon": 41.9, "alt": 200 },
      "radius": 3000000
    }
  }
}
```

Example request payload for a pyramid search:

```json
{
  "categories": [1],
  "volume": {
    "pyramid": {
      "center": { "lat": 43.0, "lon": 44.0, "alt": 0 },
      "forward": { "x": 1, "y": 0, "z": 0 },
      "right":   { "x": 0, "y": 0, "z": 1 },
      "up":      { "x": 0, "y": 1, "z": 0 },
      "length": 3000000,
      "halfAngleHorizontal": 1.56,
      "halfAngleVertical": 1.56
    }
  }
}
```

Example response:

```json
{
  "objects": [
    {
      "unit": {
        "id": 2,
        "name": "Aerial-2-1",
        "callsign": "Springfield11",
        "coalition": "COALITION_BLUE",
        "type": "A-10A",
        "position": {
          "lat": 43.80128964094778,
          "lon": 36.80316924193918,
          "alt": 1962.2799072265625,
          "u": 206424.18943715096,
          "v": -141278.69705298543
        },
        "orientation": {
          "heading": 95.71059450833623,
          "yaw": 98.36883403042783,
          "pitch": 7.451955739887493,
          "roll": 0.0000330837287922511,
          "forward": {
            "x": -0.098663330078125,
            "y": 0.12969478964805603,
            "z": 0.9866330623626709
          },
          "right": {
            "x": -0.9950371980667114,
            "y": -5.774199962615967e-7,
            "z": -0.09950366616249084
          },
          "up": {
            "x": 0.012904536910355091,
            "y": 0.9915539622306824,
            "z": -0.12905119359493256
          }
        },
        "velocity": {
          "heading": 95.7105901371753,
          "speed": 123.22611009175196,
          "velocity": {
            "x": -12.261449813842773,
            "y": 1.445429801940918,
            "z": 122.61456298828125
          }
        },
        "group": {
          "id": 2,
          "name": "Aerial-2",
          "coalition": "COALITION_BLUE",
          "category": "GROUP_CATEGORY_AIRPLANE"
        },
        "number_in_group": 1
      }
    },
    {
      "unit": {
        "id": 8,
        "name": "Ground-3-1",
        "callsign": "",
        "coalition": "COALITION_BLUE",
        "type": "mrap_mk19",
        "position": {
          "lat": 45.0422479049929,
          "lon": 38.10749053330819,
          "alt": 5.001004695892334,
          "u": 302734.90625,
          "v": 2232.5100098262274
        },
        "orientation": {
          "heading": 0,
          "yaw": 3.6502970123791134,
          "pitch": 0,
          "roll": 0,
          "forward": {
            "x": 1,
            "y": 0,
            "z": 0
          },
          "right": {
            "x": 0,
            "y": 0,
            "z": 1
          },
          "up": {
            "x": 0,
            "y": 1,
            "z": 0
          }
        },
        "velocity": {
          "heading": 0,
          "speed": 0,
          "velocity": {
            "x": 0,
            "y": 0,
            "z": 0
          }
        },
        "group": {
          "id": 8,
          "name": "Ground-3",
          "coalition": "COALITION_BLUE",
          "category": "GROUP_CATEGORY_GROUND"
        },
        "number_in_group": 1
      }
    }
  ]
}
```