### PR TITLE
Add Unit.GetSensors RPC and sensor typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- UnitService: `GetSensors` RPC to expose DCS `Unit:getSensors()` data (radar/IRST/RWR/optical).
+- Protos for sensors: `SensorCategory`, `Sensor`, `RadarSensor`, `IrstSensor`, `RwrSensor`, `OpticalSensor`, `DetectionDistanceAir`, `Hemisphere`.
+- Lua: `GRPC.methods.getSensors` implementation.
+
 ## [0.8.1] 2024-11-05
 
 ### Added

--- a/protos/dcs/unit/v0/unit.proto
+++ b/protos/dcs/unit/v0/unit.proto
@@ -34,6 +34,9 @@ service UnitService {
 
   // https://wiki.hoggitworld.com/view/DCS_func_getDrawArgumentValue
   rpc GetDrawArgumentValue(GetDrawArgumentValueRequest) returns (GetDrawArgumentValueResponse) {}
+
+  // https://wiki.hoggitworld.com/view/DCS_func_getSensors
+  rpc GetSensors(GetSensorsRequest) returns (GetSensorsResponse) {}
 }
 
 message GetRadarRequest {
@@ -116,3 +119,53 @@ message DestroyRequest {
 
 message DestroyResponse {
 }
+
+// Sensors
+message GetSensorsRequest {
+  string name = 1;
+}
+
+message GetSensorsResponse {
+  repeated SensorCategory sensors = 1;
+}
+
+message SensorCategory {
+  // DCS’ outer sensor array index (1..n)
+  uint32 category = 1;
+  repeated Sensor sensors = 2;
+}
+
+message Sensor {
+  uint32 type = 1;
+  string type_name = 2;
+  oneof sensor {
+    RadarSensor radar = 3;
+    IrstSensor irst = 4;
+    RwrSensor rwr = 5;
+    OpticalSensor optical = 6;
+  }
+}
+
+message RadarSensor {
+  DetectionDistanceAir detection_distance_air = 1;
+}
+
+message DetectionDistanceAir {
+  Hemisphere upper_hemisphere = 1;
+  Hemisphere lower_hemisphere = 2;
+}
+
+message Hemisphere {
+  double tail_on = 1;
+  double head_on = 2;
+}
+
+message IrstSensor {
+  double detection_distance_idle = 1;
+  double detection_distance_afterburner = 2;
+  double detection_distance_maximal = 3;
+}
+
+message RwrSensor {}
+
+message OpticalSensor {}

--- a/protos/dcs/unit/v0/unit.proto
+++ b/protos/dcs/unit/v0/unit.proto
@@ -166,6 +166,8 @@ message IrstSensor {
   double detection_distance_maximal = 3;
 }
 
-message RwrSensor {}
+message RwrSensor {
+}
 
-message OpticalSensor {}
+message OpticalSensor {
+}

--- a/src/rpc/unit.rs
+++ b/src/rpc/unit.rs
@@ -77,4 +77,12 @@ impl UnitService for MissionRpc {
         let res = self.request("unitDestroy", request).await?;
         Ok(Response::new(res))
     }
+
+    async fn get_sensors(
+        &self,
+        request: Request<unit::v0::GetSensorsRequest>,
+    ) -> Result<Response<unit::v0::GetSensorsResponse>, Status> {
+        let res = self.request("getSensors", request).await?;
+        Ok(Response::new(res))
+    }
 }


### PR DESCRIPTION
Introduce UnitService.GetSensors to expose DCS Unit:getSensors() with typed outputs for radar, IRST, RWR, and optical sensors.

- Add proto messages: SensorCategory, Sensor, RadarSensor, IrstSensor, RwrSensor, OpticalSensor, DetectionDistanceAir, Hemisphere
- Implement GRPC.methods.getSensors in Lua
- Wire UnitService::get_sensors in Rust
- Classify sensors by type id (0=optical, 1=radar, 2=irst, 3=rwr);