### PR TITLE
Change argument order for atan2 call in atmosphere.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Request uses `dcs.common.v0.ObjectCategory[]` and `SearchVolume` (with `InputPosition` for geo points).
   - Response returns `dcs.common.v0.Target[]` for consistent object union across services.
   - Lua implementation unwraps grpcui oneof wrapper (`volume.shape`) and supports both wrapped and flattened shapes.
+
+### Fixed
 - Fixed output of `AtmosphereService.GetWind` to match Mission Editor settings.
 
 ## [0.8.1] 2024-11-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Request uses `dcs.common.v0.ObjectCategory[]` and `SearchVolume` (with `InputPosition` for geo points).
   - Response returns `dcs.common.v0.Target[]` for consistent object union across services.
   - Lua implementation unwraps grpcui oneof wrapper (`volume.shape`) and supports both wrapped and flattened shapes.
+- Fixed output of `AtmosphereService.GetWind` to match Mission Editor settings.
 
 ## [0.8.1] 2024-11-05
 

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -26,11 +26,12 @@ impl RequestInterceptor for AuthInterceptor {
                         }
                     }
 
-                    if client.is_some() {
-                        log::debug!("Authenticated client: {}", client.unwrap());
-                        Ok(req)
-                    } else {
-                        Err(Status::unauthenticated("Unauthenticated"))
+                    match client {
+                        Some(client_name) => {
+                            log::debug!("Authenticated client: {}", client_name);
+                            Ok(req)
+                        }
+                        _ => Err(Status::unauthenticated("Unauthenticated")),
                     }
                 }
                 _ => Err(Status::unauthenticated("Unauthenticated")),

--- a/src/rpc/atmosphere.rs
+++ b/src/rpc/atmosphere.rs
@@ -39,7 +39,7 @@ impl AtmosphereService for MissionRpc {
 }
 
 fn get_wind_heading_and_strength(v: &common::v0::Vector) -> (f32, f32) {
-    let mut heading = v.x.atan2(v.z).to_degrees();
+    let mut heading = v.z.atan2(v.x).to_degrees();
     if heading < 0.0 {
         heading += 360.0;
     }

--- a/src/rpc/custom.rs
+++ b/src/rpc/custom.rs
@@ -52,6 +52,7 @@ impl CustomService for MissionRpc {
         Ok(Response::new(custom::v0::EvalResponse { json }))
     }
 
+    #[allow(clippy::result_large_err)]
     async fn get_magnetic_declination(
         &self,
         request: Request<custom::v0::GetMagneticDeclinationRequest>,


### PR DESCRIPTION
The output from the getWind rpc wasn't matching static wind set in missions. By reversing the argument order in the atan2 method in the get_wind_heading_and_strength function in atmosphere.rs, the correct output is achieved.